### PR TITLE
Table create access for users

### DIFF
--- a/engine/src/router/db.ts
+++ b/engine/src/router/db.ts
@@ -118,6 +118,7 @@ db.post('/add', async (req, res) => {
     // tables. We want to allow that in the future, but not sure the precise details of how, as
     // the various options have their own trade-offs and potential sources of bugs to worry about.
     // But we'll want to decide (before public launch?) one of them and replace this
+    // TODO: #2, also try to roll back the `GRANT CREATE` to something a bit narrower in the future
     await conn2.query(`
       CREATE ROLE ${user} LOGIN PASSWORD '${pass}';
       GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${user};
@@ -127,6 +128,7 @@ db.post('/add', async (req, res) => {
       GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO ${user};
       GRANT EXECUTE ON ALL PROCEDURES IN SCHEMA public TO ${user};
       GRANT CONNECT ON DATABASE ${dbId} TO ${user};
+      GRANT CREATE ON SCHEMA public TO ${user};
     `);
     console.log('Done!');
     res.json({


### PR DESCRIPTION
Resolves #232 

Tested and works.

Created this test account:

![Screenshot from 2021-12-08 14-48-48](https://user-images.githubusercontent.com/765551/145282925-706ef7d4-322b-40a3-917a-90fc80b4c299.png)

Used its credentials to make a table:

![Screenshot from 2021-12-08 14-51-04](https://user-images.githubusercontent.com/765551/145282960-2015c22a-6ac9-429b-a021-6113bf757015.png)

Confirmed it shows up as desired in the schema afterwards:

![Screenshot from 2021-12-08 14-51-28](https://user-images.githubusercontent.com/765551/145282998-9a911c08-5c81-4b13-90ce-193c7bc50d36.png)

This is most-researched single LOC change I've made in a while (not counting my comment)