### PR TITLE
Add sync support, and use it during module install

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -37,6 +37,9 @@ pub async fn main() {
       SubCommand::with_name("plan")
         .about("Display a preview of the resources in a db to be modified on the next `apply`")
         .arg(Arg::from_usage("[db]")),
+      SubCommand::with_name("sync")
+        .about("Synchronize db with the current state of the cloud")
+        .arg(Arg::from_usage("[db]")),
       SubCommand::with_name("install")
         .about("Install mods in a given db")
         .arg(Arg::from_usage("--db=[DB]"))
@@ -90,6 +93,10 @@ pub async fn main() {
     ("plan", Some(s_matches)) => {
       let db = db::get_or_select_db(s_matches.value_of("db")).await;
       db::plan(&db).await
+    }
+    ("sync", Some(s_matches)) => {
+      let db = db::get_or_select_db(s_matches.value_of("db")).await;
+      db::sync(&db).await
     }
     ("dbs", _) => {
       db::list().await;

--- a/engine/src/modules/aws_account/index.ts
+++ b/engine/src/modules/aws_account/index.ts
@@ -230,7 +230,9 @@ export const AwsAccount: Module = new Module({
         Object.is(a.groupName, b.groupName) &&
         Object.is(a.networkBorderGroup, b.networkBorderGroup) &&
         Object.is(a.optInStatus, b.optInStatus) &&
-        Object.is(a?.parentZone?.zoneName, b?.parentZone?.zoneName) &&
+        // TODO: Restore this in the equality check when we can be sure the db sourced records
+        // include the parentZone correctly (see below)
+        // Object.is(a?.parentZone?.zoneName, b?.parentZone?.zoneName) &&
         Object.is(a.region.name, b.region.name) &&
         Object.is(a.state, b.state),
       source: 'cloud',
@@ -249,6 +251,9 @@ export const AwsAccount: Module = new Module({
             await ctx.orm.save(AvailabilityZone, entity);
           }
         },
+        // TODO: This needs to grab and attach the `parentZone` when defined to be correct, but
+        // TypeORM cannot handle self-recursive entities properly, so we would have to do this by
+        // hand
         read: (ctx: Context, ids?: string[]) => ctx.orm.find(AvailabilityZone, ids ? {
           where: {
             zoneName: In(ids),

--- a/engine/src/router/db.ts
+++ b/engine/src/router/db.ts
@@ -76,3 +76,12 @@ db.post('/apply', async (req, res) => {
     res.status(500).end(`${handleErrorMessage(e)}`);
   }
 });
+
+db.post('/sync', async (req, res) => {
+  const { dbAlias, dryRun } = req.body;
+  try {
+    res.json(await iasql.sync(dbAlias, dryRun, req.user));
+  } catch (e) {
+    res.status(500).end(`${handleErrorMessage(e)}`);
+  }
+});


### PR DESCRIPTION
Resolves #298.

I realized this morning that it would be basically just as much work to write the code to uninstall all existing modules and then re-install them to fake `sync` as it would be to just write the `sync` functionality we've talked about. I also decided that we shouldn't be so timid and just push this forward now because it will better test our modules at the same time.