### PR TITLE
Switch to a declarative entity ID by default

### DIFF
--- a/src/modules/aws_account@0.0.1/entity/aws_account.ts
+++ b/src/modules/aws_account@0.0.1/entity/aws_account.ts
@@ -4,11 +4,14 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm'
 
+import { cloudId, } from '../../../services/cloud-id'
+
 @Entity({
   name: 'aws_account',
 })
 export class AwsAccountEntity {
   @PrimaryGeneratedColumn()
+  @cloudId
   id: number;
 
   @Column()

--- a/src/modules/aws_account@0.0.1/index.ts
+++ b/src/modules/aws_account@0.0.1/index.ts
@@ -39,7 +39,6 @@ export const AwsAccount: Module = new Module({
   mappers: {
     awsAccount: new Mapper<AwsAccountEntity>({
       entity: AwsAccountEntity,
-      entityId: (e: AwsAccountEntity) => e.id + '',
       entityPrint: (e: AwsAccountEntity) => ({
         id: e.id?.toString() ?? '',
         accessKeyId: e.accessKeyId ?? '',

--- a/src/modules/aws_cloudwatch@0.0.1/entity/log_group.ts
+++ b/src/modules/aws_cloudwatch@0.0.1/entity/log_group.ts
@@ -4,6 +4,8 @@ import {
   Column,
 } from 'typeorm'
 
+import { cloudId, } from '../../../services/cloud-id'
+
 @Entity()
 export class LogGroup {
   @PrimaryGeneratedColumn()
@@ -12,6 +14,7 @@ export class LogGroup {
   @Column({
     unique: true,
   })
+  @cloudId
   logGroupName: string;
 
   @Column({

--- a/src/modules/aws_cloudwatch@0.0.1/index.ts
+++ b/src/modules/aws_cloudwatch@0.0.1/index.ts
@@ -26,7 +26,6 @@ export const AwsCloudwatchModule: Module = new Module({
   mappers: {
     logGroup: new Mapper<LogGroup>({
       entity: LogGroup,
-      entityId: (e: LogGroup) => e.logGroupName ?? e.id,
       entityPrint: (e: LogGroup) => ({
         id: e?.id?.toString() ?? '',
         logGroupName: e?.logGroupName ?? '',

--- a/src/modules/aws_ec2@0.0.1/entity/instance.ts
+++ b/src/modules/aws_ec2@0.0.1/entity/instance.ts
@@ -5,8 +5,10 @@ import {
   ManyToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+
 // TODO: Is there a better way to deal with cross-module entities?
 import { AwsSecurityGroup, } from '../../aws_security_group@0.0.1/entity';
+import { cloudId, } from '../../../services/cloud-id'
 
 // TODO complete instance schema
 @Entity()
@@ -17,6 +19,7 @@ export class Instance {
   @Column({
     nullable: true
   })
+  @cloudId
   instanceId?: string;
 
   @Column()

--- a/src/modules/aws_ec2@0.0.1/index.ts
+++ b/src/modules/aws_ec2@0.0.1/index.ts
@@ -36,7 +36,6 @@ export const AwsEc2Module: Module = new Module({
   mappers: {
     instance: new Mapper<Instance>({
       entity: Instance,
-      entityId: (i: Instance) => i.instanceId ?? i.id?.toString() ?? '',
       entityPrint: (e: Instance) => ({
         name: e.name,
         id: e.id?.toString() ?? '',

--- a/src/modules/aws_ecr@0.0.1/entity/aws_public_repository.ts
+++ b/src/modules/aws_ecr@0.0.1/entity/aws_public_repository.ts
@@ -1,5 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, } from 'typeorm'
 
+import { cloudId, } from '../../../services/cloud-id'
+
 @Entity()
 export class AwsPublicRepository {
   @PrimaryGeneratedColumn()
@@ -10,6 +12,7 @@ export class AwsPublicRepository {
     unique: true,
     nullable: false,
   })
+  @cloudId
   repositoryName: string;
 
   @Column({

--- a/src/modules/aws_ecr@0.0.1/entity/aws_repository.ts
+++ b/src/modules/aws_ecr@0.0.1/entity/aws_repository.ts
@@ -1,5 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, } from 'typeorm'
 
+import { cloudId, } from '../../../services/cloud-id'
+
 export enum ImageTagMutability {
   IMMUTABLE = "IMMUTABLE",
   MUTABLE = "MUTABLE",
@@ -15,6 +17,7 @@ export class AwsRepository {
     unique: true,
     nullable: false,
   })
+  @cloudId
   repositoryName: string;
 
   @Column({

--- a/src/modules/aws_ecr@0.0.1/index.ts
+++ b/src/modules/aws_ecr@0.0.1/index.ts
@@ -69,7 +69,6 @@ export const AwsEcrModule: Module = new Module({
   mappers: {
     publicRepository: new Mapper<AwsPublicRepository>({
       entity: AwsPublicRepository,
-      entityId: (e: AwsPublicRepository) => e?.repositoryName ?? e.id.toString(),
       entityPrint: (e: AwsPublicRepository) => ({
         id: e?.id?.toString() ?? '',
         repositoryName: e?.repositoryName ?? '',
@@ -147,7 +146,6 @@ export const AwsEcrModule: Module = new Module({
     }),
     repository: new Mapper<AwsRepository>({
       entity: AwsRepository,
-      entityId: (e: AwsRepository) => e.repositoryName ?? e.id.toString(),
       entityPrint: (e: AwsRepository) => ({
         id: e?.id?.toString() ?? '',
         repositoryName: e?.repositoryName ?? '',

--- a/src/modules/aws_ecs_fargate@0.0.1/entity/aws_cluster.ts
+++ b/src/modules/aws_ecs_fargate@0.0.1/entity/aws_cluster.ts
@@ -4,6 +4,8 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm'
 
+import { cloudId, } from '../../../services/cloud-id'
+
 @Entity()
 export class AwsCluster {
   @PrimaryGeneratedColumn()
@@ -17,6 +19,7 @@ export class AwsCluster {
   @Column({
     nullable: true,
   })
+  @cloudId
   clusterArn?: string;
 
   @Column({

--- a/src/modules/aws_ecs_fargate@0.0.1/entity/aws_service.ts
+++ b/src/modules/aws_ecs_fargate@0.0.1/entity/aws_service.ts
@@ -10,9 +10,11 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm'
+
 import { AwsCluster, AwsTaskDefinition, AwsContainerDefinition } from '.';
 import { AwsTargetGroup } from '../../aws_elb@0.0.1/entity';
 import { AwsSecurityGroup } from '../../aws_security_group@0.0.1/entity';
+import { cloudId, } from '../../../services/cloud-id'
 
 export enum AssignPublicIp {
   DISABLED = "DISABLED",
@@ -32,6 +34,7 @@ export class AwsService {
   @Column({
     nullable: true,
   })
+  @cloudId
   arn?: string;
 
   @Column({

--- a/src/modules/aws_ecs_fargate@0.0.1/entity/aws_task_definition.ts
+++ b/src/modules/aws_ecs_fargate@0.0.1/entity/aws_task_definition.ts
@@ -7,7 +7,9 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+
 import { AwsContainerDefinition } from '.';
+import { cloudId, } from '../../../services/cloud-id'
 
 export enum TaskDefinitionStatus {
   ACTIVE = "ACTIVE",
@@ -75,6 +77,7 @@ export class AwsTaskDefinition {
   @Column({
     nullable: true,
   })
+  @cloudId
   taskDefinitionArn?: string;
 
   @Column()

--- a/src/modules/aws_ecs_fargate@0.0.1/index.ts
+++ b/src/modules/aws_ecs_fargate@0.0.1/index.ts
@@ -145,7 +145,6 @@ export const AwsEcsFargateModule: Module = new Module({
   mappers: {
     cluster: new Mapper<AwsCluster>({
       entity: AwsCluster,
-      entityId: (e: AwsCluster) => e.clusterArn ?? e.id?.toString() ?? '',
       entityPrint: (e: AwsCluster) => ({
         id: e?.id?.toString() ?? '',
         clusterName: e?.clusterName ?? '',
@@ -234,7 +233,6 @@ export const AwsEcsFargateModule: Module = new Module({
     }),
     taskDefinition: new Mapper<AwsTaskDefinition>({
       entity: AwsTaskDefinition,
-      entityId: (e: AwsTaskDefinition) => e.taskDefinitionArn ?? e.id?.toString() ?? '',
       entityPrint: (e: AwsTaskDefinition) => ({
         id: e?.id?.toString() ?? '',
         taskDefinitionArn: e?.taskDefinitionArn ?? '',
@@ -475,7 +473,6 @@ export const AwsEcsFargateModule: Module = new Module({
     }),
     service: new Mapper<AwsService>({
       entity: AwsService,
-      entityId: (e: AwsService) => e.arn ?? e.id?.toString() ?? '',
       entityPrint: (e: AwsService) => ({
         id: e?.id?.toString() ?? '',
         name: e?.name ?? '',

--- a/src/modules/aws_elb@0.0.1/entity/aws_listener.ts
+++ b/src/modules/aws_elb@0.0.1/entity/aws_listener.ts
@@ -9,6 +9,7 @@ import {
 
 import { AwsLoadBalancer, } from './aws_load_balancer'
 import { AwsTargetGroup, ProtocolEnum, } from './aws_target_group'
+import { cloudId, } from '../../../services/cloud-id'
 
 export enum ActionTypeEnum {
   // AUTHENTICATE_COGNITO = "authenticate-cognito",
@@ -25,6 +26,7 @@ export class AwsListener {
   id: number;
 
   @Column({ nullable: true, })
+  @cloudId
   listenerArn?: string;
 
   @ManyToOne(() => AwsLoadBalancer, { nullable: false, })

--- a/src/modules/aws_elb@0.0.1/entity/aws_load_balancer.ts
+++ b/src/modules/aws_elb@0.0.1/entity/aws_load_balancer.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm'
 
 import { AwsSecurityGroup } from '../../aws_security_group@0.0.1/entity'
+import { cloudId, } from '../../../services/cloud-id'
 
 export enum LoadBalancerSchemeEnum {
   INTERNAL = "internal",
@@ -45,6 +46,7 @@ export class AwsLoadBalancer {
   @Column({
     nullable: true,
   })
+  @cloudId
   loadBalancerArn?: string;
 
   @Column({

--- a/src/modules/aws_elb@0.0.1/entity/aws_target_group.ts
+++ b/src/modules/aws_elb@0.0.1/entity/aws_target_group.ts
@@ -4,6 +4,8 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm'
 
+import { cloudId, } from '../../../services/cloud-id'
+
 export enum TargetTypeEnum {
   ALB = "alb",
   INSTANCE = "instance",
@@ -51,6 +53,7 @@ export class AwsTargetGroup {
   @Column({
     nullable: true,
   })
+  @cloudId
   targetGroupArn?: string;
 
   @Column({

--- a/src/modules/aws_elb@0.0.1/index.ts
+++ b/src/modules/aws_elb@0.0.1/index.ts
@@ -106,7 +106,6 @@ export const AwsElbModule: Module = new Module({
   mappers: {
     listener: new Mapper<AwsListener>({
       entity: AwsListener,
-      entityId: (e: AwsListener) => e.listenerArn ?? e.id.toString(),
       entityPrint: (e: AwsListener) => ({
         id: e?.id?.toString() ?? '',
         listenerArn: e?.listenerArn ?? '',
@@ -230,7 +229,6 @@ export const AwsElbModule: Module = new Module({
     }),
     loadBalancer: new Mapper<AwsLoadBalancer>({
       entity: AwsLoadBalancer,
-      entityId: (e: AwsLoadBalancer) => e.loadBalancerArn ?? e.id.toString(),
       entityPrint: (e: AwsLoadBalancer) => ({
         id: e?.id?.toString() ?? '',
         loadBalancerName: e?.loadBalancerName ?? '',
@@ -411,7 +409,6 @@ export const AwsElbModule: Module = new Module({
     }),
     targetGroup: new Mapper<AwsTargetGroup>({
       entity: AwsTargetGroup,
-      entityId: (e: AwsTargetGroup) => e.targetGroupArn ?? e.id.toString(),
       entityPrint: (e: AwsTargetGroup) => ({
         id: e?.id?.toString() ?? '',
         targetGroupName: e?.targetGroupName ?? '',

--- a/src/modules/aws_rds@0.0.1/entity/rds.ts
+++ b/src/modules/aws_rds@0.0.1/entity/rds.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm'
 
 import { AwsSecurityGroup, } from '../../aws_security_group@0.0.1/entity'
+import { cloudId, } from '../../../services/cloud-id'
 
 @Entity()
 export class RDS {
@@ -18,6 +19,7 @@ export class RDS {
   @Column({
     unique: true,
   })
+  @cloudId
   dbInstanceIdentifier: string;
 
   // TODO: Add constraints? range vary based on storage type and engine

--- a/src/modules/aws_rds@0.0.1/index.ts
+++ b/src/modules/aws_rds@0.0.1/index.ts
@@ -39,7 +39,6 @@ export const AwsRdsModule: Module = new Module({
   mappers: {
     rds: new Mapper<RDS>({
       entity: RDS,
-      entityId: (e: RDS) => e.dbInstanceIdentifier ?? e.id?.toString() ?? '',
       entityPrint: (e: RDS) => ({
         id: e?.id?.toString() ?? '',
         dbInstanceIdentifier: e?.dbInstanceIdentifier ?? '',

--- a/src/modules/aws_security_group@0.0.1/entity/index.ts
+++ b/src/modules/aws_security_group@0.0.1/entity/index.ts
@@ -8,6 +8,8 @@ import {
   Unique,
 } from 'typeorm'
 
+import { cloudId, } from '../../../services/cloud-id'
+
 @Entity()
 export class AwsSecurityGroup {
   @PrimaryGeneratedColumn()
@@ -31,6 +33,7 @@ export class AwsSecurityGroup {
   @Column({
     nullable: true,
   })
+  @cloudId
   groupId?: string;
 
   @Column({
@@ -51,6 +54,7 @@ export class AwsSecurityGroupRule {
   @Column({
     nullable: true,
   })
+  @cloudId
   securityGroupRuleId?: string;
 
   @ManyToOne(() => AwsSecurityGroup)

--- a/src/modules/aws_security_group@0.0.1/index.ts
+++ b/src/modules/aws_security_group@0.0.1/index.ts
@@ -41,7 +41,6 @@ export const AwsSecurityGroupModule: Module = new Module({
   mappers: {
     securityGroup: new Mapper<AwsSecurityGroup>({
       entity: AwsSecurityGroup,
-      entityId: (e: AwsSecurityGroup) => e.groupId ?? e.id?.toString() ?? '',
       entityPrint: (e: AwsSecurityGroup) => ({
         id: e?.id?.toString() ?? '',
         description: e?.description ?? '',
@@ -237,7 +236,6 @@ export const AwsSecurityGroupModule: Module = new Module({
     }),
     securityGroupRule: new Mapper<AwsSecurityGroupRule>({
       entity: AwsSecurityGroupRule,
-      entityId: (e: AwsSecurityGroupRule) => e.securityGroupRuleId ?? e.id?.toString() ?? '',
       entityPrint: (e: AwsSecurityGroupRule) => ({
         id: e?.id?.toString() ?? '',
         securityGroupRuleId: e?.securityGroupRuleId ?? '',

--- a/src/modules/aws_vpc@0.0.1/entity/index.ts
+++ b/src/modules/aws_vpc@0.0.1/entity/index.ts
@@ -6,6 +6,8 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm'
 
+import { cloudId, } from '../../../services/cloud-id'
+
 export enum VpcState {
   AVAILABLE = 'available',
   PENDING = 'pending',
@@ -19,6 +21,7 @@ export class AwsVpc {
   @Column({
     nullable: true,
   })
+  @cloudId
   vpcId?: string;
 
   @Column()
@@ -182,6 +185,7 @@ export class AwsSubnet {
   @Column({
     nullable: true,
   })
+  @cloudId
   subnetId?: string;
 
   @Column({

--- a/src/modules/aws_vpc@0.0.1/index.ts
+++ b/src/modules/aws_vpc@0.0.1/index.ts
@@ -51,7 +51,6 @@ export const AwsVpcModule: Module = new Module({
   mappers: {
     subnet: new Mapper<AwsSubnet>({
       entity: AwsSubnet,
-      entityId: (e: AwsSubnet) => e.subnetId ?? e.id.toString(),
       entityPrint: (e: AwsSubnet) => JSON.parse(JSON.stringify(e)),
       equals: (a: AwsSubnet, b: AwsSubnet) => Object.is(a.subnetId, b.subnetId), // TODO: Do better
       source: 'db',
@@ -123,7 +122,6 @@ export const AwsVpcModule: Module = new Module({
     }),
     vpc: new Mapper<AwsVpc>({
       entity: AwsVpc,
-      entityId: (e: AwsVpc) => e.vpcId ?? e.id.toString(),
       entityPrint: (e: AwsVpc) => JSON.parse(JSON.stringify(e)),
       equals: (a: AwsVpc, b: AwsVpc) => Object.is(a.vpcId, b.vpcId), // TODO: Do better
       source: 'db',

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -244,11 +244,11 @@ export class Mapper<E> {
     this.source = def.source;
     this.db = def.db;
     this.db.entity = def.entity;
-    this.db.entityId = def.entityId;
+    this.db.entityId = this.entityId;
     this.db.dest = 'db';
     this.cloud = def.cloud;
     this.cloud.entity = def.entity;
-    this.cloud.entityId = def.entityId;
+    this.cloud.entityId = this.entityId;
     this.cloud.dest = 'cloud';
   }
 }

--- a/src/services/cloud-id.ts
+++ b/src/services/cloud-id.ts
@@ -1,0 +1,10 @@
+const cloudIdTable: { [key: string]: string, } = {};
+
+export function cloudId(Class: any, name: string, descriptor?: any) {
+  cloudIdTable[Class.constructor.name] = name;
+  return descriptor;
+}
+
+export function getCloudId(Class: any) {
+  return cloudIdTable[Class?.name ?? ''] ?? new Error(`${Class.name} was not decorated`);
+}


### PR DESCRIPTION
Resolves #476

I couldn't make it 100% because one of the entity IDs is based on the unique ID of the entity it joins (which is really weird), but also I realized I would not be able to automate the DB mapper for that entity anyways because it's `read` function is similarly weird. So I'm keeping `entityId` around as a function that is automatically populated if an override is not provided.