### PR TITLE
add plan sp and overload (un)install sp

### DIFF
--- a/src/entity/operation.ts
+++ b/src/entity/operation.ts
@@ -10,6 +10,7 @@ export enum IasqlOperationType {
   SYNC = "SYNC",
   INSTALL = "INSTALL",
   UNINSTALL = "UNINSTALL",
+  PLAN = "PLAN",
 }
 
 @Entity()

--- a/src/migration/1647526647810-init.ts
+++ b/src/migration/1647526647810-init.ts
@@ -128,8 +128,10 @@ export class init1647526647810 implements MigrationInterface {
         await queryRunner.query(`DROP PROCEDURE "iasql_apply"`);
         await queryRunner.query(`DROP PROCEDURE "iasql_plan"`);
         await queryRunner.query(`DROP PROCEDURE "iasql_sync"`);
-        await queryRunner.query(`DROP PROCEDURE "iasql_install"`);
-        await queryRunner.query(`DROP PROCEDURE "iasql_uninstall"`);
+        await queryRunner.query(`DROP PROCEDURE "iasql_install(_mod text)"`);
+        await queryRunner.query(`DROP PROCEDURE "iasql_install(_mods text[])"`);
+        await queryRunner.query(`DROP PROCEDURE "iasql_uninstall(_mod text)"`);
+        await queryRunner.query(`DROP PROCEDURE "iasql_uninstall(_mods text[])"`);
         await queryRunner.query(`ALTER TABLE "iasql_dependencies" DROP CONSTRAINT "FK_7dbdaef2c45fdd0d1d82cc9568c"`);
         await queryRunner.query(`ALTER TABLE "iasql_dependencies" DROP CONSTRAINT "FK_9732df6d7dff34b6f6a1732033b"`);
         await queryRunner.query(`ALTER TABLE "iasql_tables" DROP CONSTRAINT "FK_0e0f2a4ef99e93cfcb935c060cb"`);

--- a/src/migration/1647526647810-init.ts
+++ b/src/migration/1647526647810-init.ts
@@ -128,10 +128,10 @@ export class init1647526647810 implements MigrationInterface {
         await queryRunner.query(`DROP PROCEDURE "iasql_apply"`);
         await queryRunner.query(`DROP PROCEDURE "iasql_plan"`);
         await queryRunner.query(`DROP PROCEDURE "iasql_sync"`);
-        await queryRunner.query(`DROP PROCEDURE "iasql_install(_mod text)"`);
-        await queryRunner.query(`DROP PROCEDURE "iasql_install(_mods text[])"`);
-        await queryRunner.query(`DROP PROCEDURE "iasql_uninstall(_mod text)"`);
-        await queryRunner.query(`DROP PROCEDURE "iasql_uninstall(_mods text[])"`);
+        await queryRunner.query(`DROP PROCEDURE "iasql_install(text)"`);
+        await queryRunner.query(`DROP PROCEDURE "iasql_install(text[])"`);
+        await queryRunner.query(`DROP PROCEDURE "iasql_uninstall(text)"`);
+        await queryRunner.query(`DROP PROCEDURE "iasql_uninstall(text[])"`);
         await queryRunner.query(`ALTER TABLE "iasql_dependencies" DROP CONSTRAINT "FK_7dbdaef2c45fdd0d1d82cc9568c"`);
         await queryRunner.query(`ALTER TABLE "iasql_dependencies" DROP CONSTRAINT "FK_9732df6d7dff34b6f6a1732033b"`);
         await queryRunner.query(`ALTER TABLE "iasql_tables" DROP CONSTRAINT "FK_0e0f2a4ef99e93cfcb935c060cb"`);

--- a/src/migration/1647526647810-init.ts
+++ b/src/migration/1647526647810-init.ts
@@ -112,11 +112,21 @@ export class init1647526647810 implements MigrationInterface {
             end;
             $$;
         `);
+        await queryRunner.query(`
+            create or replace procedure iasql_uninstall(_mod text)
+            language plpgsql
+            as $$
+            begin
+                call until_iasql_operation('UNINSTALL', array[_mod]);
+            end;
+            $$;
+        `);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`DROP PROCEDURE "until_iasql_operation"`);
         await queryRunner.query(`DROP PROCEDURE "iasql_apply"`);
+        await queryRunner.query(`DROP PROCEDURE "iasql_plan"`);
         await queryRunner.query(`DROP PROCEDURE "iasql_sync"`);
         await queryRunner.query(`DROP PROCEDURE "iasql_install"`);
         await queryRunner.query(`DROP PROCEDURE "iasql_uninstall"`);

--- a/src/migration/1647526647810-init.ts
+++ b/src/migration/1647526647810-init.ts
@@ -6,7 +6,7 @@ export class init1647526647810 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TABLE "iasql_module" ("name" character varying NOT NULL, CONSTRAINT "UQ_e91a0b0e9a029428405fdd17ee4" UNIQUE ("name"), CONSTRAINT "PK_e91a0b0e9a029428405fdd17ee4" PRIMARY KEY ("name"))`);
         await queryRunner.query(`CREATE TABLE "iasql_tables" ("table" character varying NOT NULL, "module" character varying NOT NULL, CONSTRAINT "PK_2e2832f9cf90115571eb803a943" PRIMARY KEY ("table", "module"))`);
-        await queryRunner.query(`CREATE TYPE "public"."iasql_operation_optype_enum" AS ENUM('APPLY', 'SYNC', 'INSTALL', 'UNINSTALL')`);
+        await queryRunner.query(`CREATE TYPE "public"."iasql_operation_optype_enum" AS ENUM('APPLY', 'SYNC', 'INSTALL', 'UNINSTALL', 'PLAN')`);
         await queryRunner.query(`CREATE TABLE "iasql_operation" ("opid" uuid NOT NULL, "start_date" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "end_date" TIMESTAMP WITH TIME ZONE, "optype" "public"."iasql_operation_optype_enum" NOT NULL, "params" text array NOT NULL, "output" text, "err" text, CONSTRAINT "PK_edf11c327fef1bf78dd04cdf3ce" PRIMARY KEY ("opid"))`);
         await queryRunner.query(`CREATE TABLE "iasql_dependencies" ("module" character varying NOT NULL, "dependency" character varying NOT NULL, CONSTRAINT "PK_b07797cfc364fa84b6da165f89d" PRIMARY KEY ("module", "dependency"))`);
         await queryRunner.query(`CREATE INDEX "IDX_9732df6d7dff34b6f6a1732033" ON "iasql_dependencies" ("module") `);
@@ -68,6 +68,15 @@ export class init1647526647810 implements MigrationInterface {
             $$;
         `);
         await queryRunner.query(`
+            create or replace procedure iasql_plan()
+            language plpgsql
+            as $$
+            begin
+                call until_iasql_operation('PLAN', array[]::text[]);
+            end;
+            $$;
+        `);
+        await queryRunner.query(`
             create or replace procedure iasql_sync()
             language plpgsql
             as $$
@@ -82,6 +91,15 @@ export class init1647526647810 implements MigrationInterface {
             as $$
             begin
                 call until_iasql_operation('INSTALL', _mods);
+            end;
+            $$;
+        `);
+        await queryRunner.query(`
+            create or replace procedure iasql_install(_mod text)
+            language plpgsql
+            as $$
+            begin
+                call until_iasql_operation('INSTALL', array[_mod]);
             end;
             $$;
         `);

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -30,7 +30,7 @@ export async function start(dbAlias: string, dbId:string, uid: string) {
             break;
           }
           case IasqlOperationType.PLAN: {
-            promise = iasql.apply(dbAlias, true, user, conn);
+            promise = iasql.apply(dbAlias, true, uid, conn);
             break;
           }
           case IasqlOperationType.SYNC: {

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -29,6 +29,10 @@ export async function start(dbAlias: string, dbId:string, uid: string) {
             promise = iasql.apply(dbAlias, false, uid, conn);
             break;
           }
+          case IasqlOperationType.PLAN: {
+            promise = iasql.apply(dbAlias, true, user, conn);
+            break;
+          }
           case IasqlOperationType.SYNC: {
             promise = iasql.sync(dbAlias, false, uid, conn);
             break;

--- a/test/modules/aws-account-integration.ts
+++ b/test/modules/aws-account-integration.ts
@@ -45,6 +45,10 @@ describe('AwsAccount Integration Testing', () => {
 
   it('does absolutely nothing when you sync this', sync());
 
+  it('does absolutely nothing when you plan this', query(`
+    call iasql_plan();
+  `));
+
   it('removes the useless row', query(`
     DELETE FROM aws_account WHERE access_key_id = 'fake'
   `));

--- a/test/modules/aws-ec2-integration.ts
+++ b/test/modules/aws-ec2-integration.ts
@@ -152,7 +152,9 @@ describe('EC2 install/uninstall', () => {
 
   it('uninstalls the ec2 module', uninstall(['aws_ec2@0.0.1']));
 
-  it('installs the ec2 module', install(['aws_ec2@0.0.1']));
+  it('install using overloaded sp', query(`
+    call iasql_install('aws_ec2@0.0.1');
+  `));
 
   it('deletes the test db', (done) => void iasql
     .remove(dbAlias, 'not-needed')

--- a/test/modules/aws-ec2-integration.ts
+++ b/test/modules/aws-ec2-integration.ts
@@ -150,8 +150,6 @@ describe('EC2 install/uninstall', () => {
     'not-needed',
     true).then(...finish(done)));
 
-  it('uninstalls the ec2 module', uninstall(['aws_ec2@0.0.1']));
-
   it('uninstall ec2 using overloaded sp', query(`
     call iasql_uninstall('aws_ec2@0.0.1');
   `));

--- a/test/modules/aws-ec2-integration.ts
+++ b/test/modules/aws-ec2-integration.ts
@@ -152,7 +152,11 @@ describe('EC2 install/uninstall', () => {
 
   it('uninstalls the ec2 module', uninstall(['aws_ec2@0.0.1']));
 
-  it('install using overloaded sp', query(`
+  it('uninstall ec2 using overloaded sp', query(`
+    call iasql_uninstall('aws_ec2@0.0.1');
+  `));
+
+  it('install ec2 using overloaded sp', query(`
     call iasql_install('aws_ec2@0.0.1');
   `));
 


### PR DESCRIPTION
add `iasql_plan` and overload the `iasql_install` sp so that it can also be called with just a `text` argument. without this one needs to always pass an array even if it only has one `text` element in it.
before: `call iasql_install(array['aws_vpc@0.0.1'])`
now: `call iasql_install('aws_vpc@0.0.1')`