### PR TITLE
Automate the population of the 'tables' and 'functions' fields in the 'provides' sub-object

### DIFF
--- a/src/modules/aws_account@0.0.1/index.ts
+++ b/src/modules/aws_account@0.0.1/index.ts
@@ -10,9 +10,6 @@ export const AwsAccount: Module = new Module({
   ...metadata,
   provides: {
     entities: allEntities,
-    tables: [
-      'aws_account',
-    ],
     context: {
       // This function is `async function () {` instead of `async () => {` because that enables the
       // `this` keyword within the function based on the objec it is being called from, so the

--- a/src/modules/aws_cloudwatch@0.0.1/index.ts
+++ b/src/modules/aws_cloudwatch@0.0.1/index.ts
@@ -8,7 +8,6 @@ export const AwsCloudwatchModule: Module = new Module({
   ...metadata,
   provides: {
     entities: allEntities,
-    tables: ['log_group',],
   },
   utils: {
     logGroupMapper: (lg: any, _ctx: Context) => {

--- a/src/modules/aws_ec2@0.0.1/index.ts
+++ b/src/modules/aws_ec2@0.0.1/index.ts
@@ -11,9 +11,6 @@ export const AwsEc2Module: Module = new Module({
   ...metadata,
   provides: {
     entities: allEntities,
-    tables: [
-      'instance', 'instance_security_groups',
-    ],
   },
   utils: {
     instanceMapper: async (instance: InstanceAWS, ctx: Context) => {

--- a/src/modules/aws_ecr@0.0.1/index.ts
+++ b/src/modules/aws_ecr@0.0.1/index.ts
@@ -13,7 +13,6 @@ export const AwsEcrModule: Module = new Module({
   ...metadata,
   provides: {
     entities: allEntities,
-    tables: ['repository', 'repository_policy', 'public_repository',],
   },
   utils: {
     publicRepositoryMapper: (r: PublicRepositoryAws, _ctx: Context) => {

--- a/src/modules/aws_ecs_fargate@0.0.1/index.ts
+++ b/src/modules/aws_ecs_fargate@0.0.1/index.ts
@@ -17,7 +17,6 @@ export const AwsEcsFargateModule: Module = new Module({
   ...metadata,
   provides: {
     entities: allEntities,
-    tables: ['cluster', 'container_definition', 'task_definition', 'service', 'service_security_groups'],
   },
   utils: {
     clusterMapper: (c: any, _ctx: Context) => {

--- a/src/modules/aws_elb@0.0.1/index.ts
+++ b/src/modules/aws_elb@0.0.1/index.ts
@@ -29,7 +29,6 @@ export const AwsElbModule: Module = new Module({
   ...metadata,
   provides: {
     entities: allEntities,
-    tables: ['target_group', 'load_balancer', 'listener', 'load_balancer_security_groups',],
   },
   utils: {
     listenerMapper: async (l: ListenerAws, ctx: Context) => {

--- a/src/modules/aws_rds@0.0.1/index.ts
+++ b/src/modules/aws_rds@0.0.1/index.ts
@@ -12,7 +12,6 @@ export const AwsRdsModule: Module = new Module({
   ...metadata,
   provides: {
     entities: allEntities,
-    tables: ['rds', 'rds_security_groups',],
   },
   utils: {
     rdsMapper: async (rds: any, ctx: Context) => {

--- a/src/modules/aws_security_group@0.0.1/index.ts
+++ b/src/modules/aws_security_group@0.0.1/index.ts
@@ -10,7 +10,6 @@ export const AwsSecurityGroupModule: Module = new Module({
   ...metadata,
   provides: {
     entities: allEntities,
-    tables: ['security_group', 'security_group_rule'],
   },
   utils: {
     sgMapper: async (sg: any, _ctx: Context) => {

--- a/src/modules/aws_vpc@0.0.1/index.ts
+++ b/src/modules/aws_vpc@0.0.1/index.ts
@@ -16,7 +16,6 @@ export const AwsVpcModule: Module = new Module({
   ...metadata,
   provides: {
     entities: allEntities,
-    tables: ['subnet', 'vpc'],
   },
   utils: {
     subnetMapper: async (sn: AwsSubnet, ctx: Context) => {

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -349,6 +349,9 @@ export class Module {
           .replace(/\basync\b/g, '')
           .replace(/\bawait\b/g, '')
           .replace(/^/, 'function')
+          // The following are only for the test suite, but need to be included at all times
+          .replace(/\/* istanbul ignore next *\//g, '')
+          .replace(/cov_.*/g, '')
       )();
       const tables: string[] = [];
       const functions: string[] = [];

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -304,8 +304,8 @@ export class Module {
   dependencies: string[];
   provides: {
     entities: { [key: string]: any, };
-    tables?: string[];
-    functions?: string[];
+    tables: string[];
+    functions: string[];
     context?: Context;
   };
   utils: { [key: string]: any, };
@@ -319,7 +319,12 @@ export class Module {
     this.name = def.name;
     this.version = def.version;
     this.dependencies = def.dependencies;
-    this.provides = def.provides;
+    this.provides = {
+      entities: def.provides.entities,
+      tables: def.provides.tables ?? [], // These will be populated automatically below
+      functions: def.provides.functions ?? [],
+    }
+    if (def.provides.context) this.provides.context = def.provides.context;
     this.utils = def?.utils ?? {};
     this.mappers = def.mappers;
     if (!def.migrations) {
@@ -337,6 +342,29 @@ export class Module {
         install: migrationClass.prototype.up,
         remove: migrationClass.prototype.down,
       };
+      const syncified = new Function(
+        'return ' +
+        migrationClass.prototype.up
+          .toString()
+          .replace(/\basync\b/g, '')
+          .replace(/\bawait\b/g, '')
+          .replace(/^/, 'function')
+      )();
+      const tables: string[] = [];
+      const functions: string[] = [];
+      syncified({ query: (text: string) => {
+        // TODO: Proper parsing (maybe LP?)
+        if (/^create table/i.test(text)) {
+          tables.push((text.match(/^[^"]*"([^"]*)"/) ?? [])[1]);
+        } else if (/^create or replace procedure/i.test(text)) {
+          functions.push((text.match(/^create or replace procedure ([^(]*)/i) ?? [])[0]);
+        } else if (/^create or replace function/i.test(text)) {
+          functions.push((text.match(/^create or replace function ([^(]*)/i) ?? [])[0]);
+        }
+        // Don't do anything for queries that don't match
+      }, });
+      if (!def.provides.tables) this.provides.tables = tables;
+      if (!def.provides.functions) this.provides.functions = functions;
     } else {
       this.migrations = def.migrations;
     }


### PR DESCRIPTION
This is the first half of #478

The second half is automating the `entities` field (will be in a separate PR