### PR TITLE
Automate the entities list for modules

### DIFF
--- a/src/modules/aws_account@0.0.1/index.ts
+++ b/src/modules/aws_account@0.0.1/index.ts
@@ -2,14 +2,12 @@ import { In, } from 'typeorm'
 
 import { AWS, } from '../../services/gateways/aws'
 import { AwsAccountEntity, } from './entity'
-import * as allEntities from './entity'
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import * as metadata from './module.json'
 
 export const AwsAccount: Module = new Module({
   ...metadata,
   provides: {
-    entities: allEntities,
     context: {
       // This function is `async function () {` instead of `async () => {` because that enables the
       // `this` keyword within the function based on the objec it is being called from, so the

--- a/src/modules/aws_cloudwatch@0.0.1/index.ts
+++ b/src/modules/aws_cloudwatch@0.0.1/index.ts
@@ -1,14 +1,10 @@
 import { AWS, } from '../../services/gateways/aws'
-import * as allEntities from './entity'
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import { LogGroup } from './entity'
 import * as metadata from './module.json'
 
 export const AwsCloudwatchModule: Module = new Module({
   ...metadata,
-  provides: {
-    entities: allEntities,
-  },
   utils: {
     logGroupMapper: (lg: any, _ctx: Context) => {
       const out = new LogGroup();

--- a/src/modules/aws_ec2@0.0.1/index.ts
+++ b/src/modules/aws_ec2@0.0.1/index.ts
@@ -1,6 +1,5 @@
 import { Instance as InstanceAWS, } from '@aws-sdk/client-ec2'
 
-import * as allEntities from './entity'
 import { Instance, } from './entity'
 import { AwsSecurityGroupModule, } from '../aws_security_group@0.0.1'
 import { AWS, IASQL_EC2_TAG_NAME } from '../../services/gateways/aws'
@@ -9,9 +8,6 @@ import * as metadata from './module.json'
 
 export const AwsEc2Module: Module = new Module({
   ...metadata,
-  provides: {
-    entities: allEntities,
-  },
   utils: {
     instanceMapper: async (instance: InstanceAWS, ctx: Context) => {
       const out = new Instance();

--- a/src/modules/aws_ecr@0.0.1/index.ts
+++ b/src/modules/aws_ecr@0.0.1/index.ts
@@ -5,15 +5,11 @@ import { Repository as PublicRepositoryAws, } from '@aws-sdk/client-ecr-public'
 
 import { AWS, } from '../../services/gateways/aws'
 import { PublicRepository, Repository, RepositoryPolicy, ImageTagMutability, } from './entity'
-import * as allEntities from './entity'
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import * as metadata from './module.json'
 
 export const AwsEcrModule: Module = new Module({
   ...metadata,
-  provides: {
-    entities: allEntities,
-  },
   utils: {
     publicRepositoryMapper: (r: PublicRepositoryAws, _ctx: Context) => {
       const out = new Repository();

--- a/src/modules/aws_ecs_fargate@0.0.1/index.ts
+++ b/src/modules/aws_ecs_fargate@0.0.1/index.ts
@@ -8,16 +8,12 @@ import {
   Service,
   TaskDefinition,
 } from './entity'
-import * as allEntities from './entity'
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import { AwsEcrModule, AwsElbModule, AwsSecurityGroupModule, AwsCloudwatchModule, } from '..'
 import * as metadata from './module.json'
 
 export const AwsEcsFargateModule: Module = new Module({
   ...metadata,
-  provides: {
-    entities: allEntities,
-  },
   utils: {
     clusterMapper: (c: any, _ctx: Context) => {
       const out = new Cluster();

--- a/src/modules/aws_elb@0.0.1/index.ts
+++ b/src/modules/aws_elb@0.0.1/index.ts
@@ -20,16 +20,12 @@ import {
   TargetGroupIpAddressTypeEnum,
   TargetTypeEnum,
 } from './entity'
-import * as allEntities from './entity'
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import { AwsSecurityGroupModule } from '..'
 import * as metadata from './module.json'
 
 export const AwsElbModule: Module = new Module({
   ...metadata,
-  provides: {
-    entities: allEntities,
-  },
   utils: {
     listenerMapper: async (l: ListenerAws, ctx: Context) => {
       const out = new Listener();

--- a/src/modules/aws_rds@0.0.1/index.ts
+++ b/src/modules/aws_rds@0.0.1/index.ts
@@ -3,16 +3,12 @@ import { ModifyDBInstanceCommandInput } from '@aws-sdk/client-rds'
 
 import { AWS, } from '../../services/gateways/aws'
 import { RDS, } from './entity'
-import * as allEntities from './entity'
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import { AwsSecurityGroupModule } from '..'
 import * as metadata from './module.json'
 
 export const AwsRdsModule: Module = new Module({
   ...metadata,
-  provides: {
-    entities: allEntities,
-  },
   utils: {
     rdsMapper: async (rds: any, ctx: Context) => {
       const out = new RDS();

--- a/src/modules/aws_security_group@0.0.1/index.ts
+++ b/src/modules/aws_security_group@0.0.1/index.ts
@@ -2,15 +2,11 @@ import { In, } from 'typeorm'
 
 import { AWS, } from '../../services/gateways/aws'
 import { SecurityGroup, SecurityGroupRule, } from './entity'
-import * as allEntities from './entity'
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import * as metadata from './module.json'
 
 export const AwsSecurityGroupModule: Module = new Module({
   ...metadata,
-  provides: {
-    entities: allEntities,
-  },
   utils: {
     sgMapper: async (sg: any, _ctx: Context) => {
       const out = new SecurityGroup();

--- a/src/modules/aws_vpc@0.0.1/index.ts
+++ b/src/modules/aws_vpc@0.0.1/index.ts
@@ -8,15 +8,11 @@ import {
   SubnetState,
   VpcState,
 } from './entity'
-import * as allEntities from './entity'
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import * as metadata from './module.json'
 
 export const AwsVpcModule: Module = new Module({
   ...metadata,
-  provides: {
-    entities: allEntities,
-  },
   utils: {
     subnetMapper: async (sn: AwsSubnet, ctx: Context) => {
       const out = new Subnet();

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -263,7 +263,7 @@ export async function apply(dbId: string, dryRun: boolean, ormOpt?: TypeormWrapp
     const memo: any = {}; // TODO: Stronger typing here
     const context: Modules.Context = { orm, memo, }; // Every module gets access to the DB
     for (const name of moduleNames) {
-      const mod = (Object.values(Modules) as Modules.ModuleInterface[]).find(m => `${m.name}@${m.version}` === name) as Modules.ModuleInterface;
+      const mod = (Object.values(Modules) as Modules.Module[]).find(m => `${m.name}@${m.version}` === name) as Modules.Module;
       if (!mod) throw new Error(`This should be impossible. Cannot find module ${name}`);
       const moduleContext = mod.provides.context ?? {};
       Object.keys(moduleContext).forEach(k => context[k] = moduleContext[k]);
@@ -474,7 +474,7 @@ export async function sync(dbId: string, dryRun: boolean, ormOpt?: TypeormWrappe
     const memo: any = {}; // TODO: Stronger typing here
     const context: Modules.Context = { orm, memo, }; // Every module gets access to the DB
     for (const name of moduleNames) {
-      const mod = (Object.values(Modules) as Modules.ModuleInterface[]).find(m => `${m.name}@${m.version}` === name) as Modules.ModuleInterface;
+      const mod = (Object.values(Modules) as Modules.Module[]).find(m => `${m.name}@${m.version}` === name) as Modules.Module;
       if (!mod) throw new Error(`This should be impossible. Cannot find module ${name}`);
       const moduleContext = mod.provides.context ?? {};
       Object.keys(moduleContext).forEach(k => context[k] = moduleContext[k]);
@@ -695,7 +695,7 @@ export async function install(moduleList: string[], dbId: string, dbUser: string
   if (allModules) {
     moduleList = (Object.values(Modules) as Modules.ModuleInterface[]).filter((m: Modules.ModuleInterface) => m.name && m.version && m.name !== 'aws_account' ).map((m: Modules.ModuleInterface) => `${m.name}@${m.version}`);
   }
-  const mods = moduleList.map((n: string) => (Object.values(Modules) as Modules.ModuleInterface[]).find(m => `${m.name}@${m.version}` === n)) as Modules.ModuleInterface[];
+  const mods = moduleList.map((n: string) => (Object.values(Modules) as Modules.Module[]).find(m => `${m.name}@${m.version}` === n)) as Modules.Module[];
   if (mods.some((m: any) => m === undefined)) {
     throw new Error(`The following modules do not exist: ${
       moduleList.filter((n: string) => !(Object.values(Modules) as Modules.ModuleInterface[]).find(m => `${m.name}@${m.version}` === n)).join(', ')
@@ -715,7 +715,7 @@ export async function install(moduleList: string[], dbId: string, dbUser: string
   // TODO rm special casing for aws_account
   // Check to make sure that all dependent modules are in the list
   const missingDeps = mods
-    .flatMap((m: Modules.ModuleInterface) => m.dependencies.filter(d => !moduleList.includes(d) && !existingModules.includes(d)))
+    .flatMap((m: Modules.Module) => m.dependencies.filter(d => !moduleList.includes(d) && !existingModules.includes(d)))
     .filter((m: any) => m !== 'aws_account@0.0.1' && m !== undefined);
   if (missingDeps.length > 0) {
     throw new Error(`The provided modules depend on the following modules that are not provided or installed: ${
@@ -808,7 +808,7 @@ ${Object.keys(tableCollisions)
   const moduleNames = (await orm.find(IasqlModule)).map((m: IasqlModule) => m.name);
   const context: Modules.Context = { orm, memo: {}, }; // Every module gets access to the DB
   for (const name of moduleNames) {
-    const md = (Object.values(Modules) as Modules.ModuleInterface[]).find(m => `${m.name}@${m.version}` === name) as Modules.ModuleInterface;
+    const md = (Object.values(Modules) as Modules.Module[]).find(m => `${m.name}@${m.version}` === name) as Modules.Module;
     if (!md) throw new Error(`This should be impossible. Cannot find module ${name}`);
     const moduleContext = md.provides.context ?? {};
     Object.keys(moduleContext).forEach(k => context[k] = moduleContext[k]);
@@ -849,7 +849,7 @@ ${Object.keys(tableCollisions)
 
 export async function uninstall(moduleList: string[], dbId: string, orm?: TypeormWrapper) {
   // Check to make sure that all specified modules actually exist
-  const mods = moduleList.map((n: string) => (Object.values(Modules) as Modules.ModuleInterface[]).find(m => `${m.name}@${m.version}` === n)) as Modules.ModuleInterface[];
+  const mods = moduleList.map((n: string) => (Object.values(Modules) as Modules.Module[]).find(m => `${m.name}@${m.version}` === n)) as Modules.Module[];
   if (mods.some((m: any) => m === undefined)) {
     throw new Error(`The following modules do not exist: ${
       moduleList.filter((n: string) => !(Object.values(Modules) as Modules.ModuleInterface[]).find(m => `${m.name}@${m.version}` === n)).join(', ')

--- a/src/services/mod-sort.ts
+++ b/src/services/mod-sort.ts
@@ -1,6 +1,6 @@
-import { ModuleInterface, } from '../modules/interfaces'
+import { Module, } from '../modules/interfaces'
 
-export const sortModules = (modules: ModuleInterface[], existingModules: string[]) => {
+export const sortModules = (modules: Module[], existingModules: string[]) => {
   const moduleList = [...modules];
   const sortedModuleNames: { [key: string]: boolean } = {};
   const sortedModules = [];

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -15,7 +15,7 @@ const workerShutdownEmitter = new EventEmitter();
 // (graphile_worker) and migrations in each uid db using our credentials
 export async function start(dbId: string, dbUser:string) {
   // use the same connection for the scheduler and its operations
-  const conn = await TypeormWrapper.createConn(`${dbId}-scheduler`);
+  const conn = await TypeormWrapper.createConn(dbId, { name: `${dbId}-${Math.floor(Math.random()*10000)}-scheduler`, });
   const runner = await run({
     pgPool: conn.getMasterConnection(),
     concurrency: 5,

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -15,7 +15,7 @@ const workerShutdownEmitter = new EventEmitter();
 // (graphile_worker) and migrations in each uid db using our credentials
 export async function start(dbId: string, dbUser:string) {
   // use the same connection for the scheduler and its operations
-  const conn = await TypeormWrapper.createConn(dbId);
+  const conn = await TypeormWrapper.createConn(`${dbId}-scheduler`);
   const runner = await run({
     pgPool: conn.getMasterConnection(),
     concurrency: 5,

--- a/src/services/typeorm.ts
+++ b/src/services/typeorm.ts
@@ -42,8 +42,8 @@ export class TypeormWrapper {
     }
     const connOpts: PostgresConnectionOptions = {
       ...typeorm.connectionConfig,
+      name: dbname,
       ...connectionConfig as PostgresConnectionOptions,
-      name: dbname, // TODO improve connection name handling
       database,
     }
     typeorm.connection = await createConnection(connOpts);

--- a/test/common/dep-sorting.ts
+++ b/test/common/dep-sorting.ts
@@ -1,11 +1,11 @@
 import { sortModules, } from '../../src/services/mod-sort'
-import { ModuleInterface, } from '../../src/modules/interfaces'
+import { Module, } from '../../src/modules/interfaces'
 
 const fakeMod = (name: string, dependencies: string[]) => ({
   name,
   version: '0.0.1',
   dependencies,
-} as ModuleInterface);
+} as Module);
 
 describe('Module Sorting', () => {
   it('should sort from root to leaf order', () => {


### PR DESCRIPTION
Resolves #478

This also eliminates the path where custom `install` and `remove` functions can be provided outside of the TypeORM migration path, as TypeORM is now 100% required for our modules.