### PR TITLE
Better test logging

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -12,6 +12,7 @@ export interface ConfigInterface {
   sentryEnvironment?: string;
   sentryDsn?: string;
   debugLogger?: boolean;
+  testLogger?: boolean;
 };
 
 export const throwError = (message: string): never => { throw new Error(message); };

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -14,6 +14,7 @@ const config: ConfigInterface = {
   sentryDsn: undefined,
   sentryEnvironment: undefined,
   debugLogger: false,
+  testLogger: true,
 };
 
 export default config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import config from './config';
 import { v1 } from './router';
 import MetadataRepo from './services/repositories/metadata';
 import * as scheduler from './services/scheduler'
+import logger from './services/logger'
 
 const port = config.port;
 const app = express();
@@ -43,7 +44,7 @@ if (config.sentryEnabled) {
 app.use((error: any, _req: any, res: any, _next: any) => {
   // The error id is attached to `res.sentry` to be returned
   // and optionally displayed to the user for support.
-  console.error(inspect(error));
+  logger.error(inspect(error));
   let msg = error.message || inspect(error);
   if (config.sentryEnabled) msg += `\nPlease provide this error ID when reporting this bug: ${res.sentry}`;
   return res
@@ -55,7 +56,7 @@ app.use((error: any, _req: any, res: any, _next: any) => {
 MetadataRepo.init().then(() => {
   scheduler.init().then(() => {
     app.listen(port, () => {
-      console.log(`Server is running on port ${port}`);
+      logger.info(`Server is running on port ${port}`);
     });
   })
 });

--- a/src/modules/aws_ecr@0.0.1/index.ts
+++ b/src/modules/aws_ecr@0.0.1/index.ts
@@ -4,6 +4,7 @@ import { Repository as RepositoryAws, } from '@aws-sdk/client-ecr'
 import { Repository as PublicRepositoryAws, } from '@aws-sdk/client-ecr-public'
 
 import { AWS, } from '../../services/gateways/aws'
+import logger from '../../services/logger'
 import { PublicRepository, Repository, RepositoryPolicy, ImageTagMutability, } from './entity'
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import * as metadata from './module.json'
@@ -286,7 +287,7 @@ export const AwsEcrModule: Module = new Module({
                 return AwsEcrModule.mappers.repositoryPolicy.cloud.create(e, ctx);
               }
             } catch (e) {
-              console.log('Error comparing policy records');
+              logger.error('Error comparing policy records');
             }
             cloudRecord.id = e.id;
             await AwsEcrModule.mappers.repositoryPolicy.db.update(cloudRecord, ctx);

--- a/src/modules/aws_ecs_fargate@0.0.1/index.ts
+++ b/src/modules/aws_ecs_fargate@0.0.1/index.ts
@@ -59,7 +59,7 @@ export const AwsEcsFargateModule: Module = new Module({
           out.repository = repository;
         } catch (e) {
           // Repository could have been deleted
-          logger.error(e);
+          logger.error('Repository not found', e as any);
           out.repository = undefined;
         }
       } else if (containerImage?.includes('public.ecr.aws')) {  // Public ECR
@@ -71,7 +71,7 @@ export const AwsEcsFargateModule: Module = new Module({
           out.publicRepository = publicRepository;
         } catch (e) {
           // Repository could have been deleted
-          logger.error(e);
+          logger.error('Repository not found', e as any);
           out.publicRepository = undefined;
         }
       }

--- a/src/modules/aws_ecs_fargate@0.0.1/index.ts
+++ b/src/modules/aws_ecs_fargate@0.0.1/index.ts
@@ -11,6 +11,7 @@ import {
 import { Context, Crud, Mapper, Module, } from '../interfaces'
 import { AwsEcrModule, AwsElbModule, AwsSecurityGroupModule, AwsCloudwatchModule, } from '..'
 import * as metadata from './module.json'
+import logger from '../../services/logger'
 
 export const AwsEcsFargateModule: Module = new Module({
   ...metadata,
@@ -58,7 +59,7 @@ export const AwsEcsFargateModule: Module = new Module({
           out.repository = repository;
         } catch (e) {
           // Repository could have been deleted
-          console.error(e);
+          logger.error(e);
           out.repository = undefined;
         }
       } else if (containerImage?.includes('public.ecr.aws')) {  // Public ECR
@@ -70,7 +71,7 @@ export const AwsEcsFargateModule: Module = new Module({
           out.publicRepository = publicRepository;
         } catch (e) {
           // Repository could have been deleted
-          console.error(e);
+          logger.error(e);
           out.publicRepository = undefined;
         }
       }
@@ -305,7 +306,7 @@ export const AwsEcsFargateModule: Module = new Module({
                   }
                   image = c.publicRepository.repositoryUri;
                 } else {
-                  console.error('How the DB constraint have been ignored?');
+                  logger.error('How the DB constraint have been ignored?');
                 }
                 if (c.digest) {
                   container.image = `${image}@${c.digest}`;

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import { In, QueryRunner, getMetadataArgsStorage, } from 'typeorm'
 
 import { getCloudId, } from '../services/cloud-id'
+import logger from '../services/logger'
 
 // The exported interfaces are meant to provide better type checking both at compile time and in the
 // editor. They *shouldn't* have to be ever imported directly, only the classes ought to be, but as
@@ -78,7 +79,7 @@ export class Crud<E> {
   }
 
   async create(e: E | E[], ctx: Context) {
-    console.log(`Calling ${this.entity?.name ?? ''} ${this.dest} create`);
+    logger.info(`Calling ${this.entity?.name ?? ''} ${this.dest} create`);
     const es = Array.isArray(e) ? e : [e];
     // Memoize before and after the actual logic to make sure the unique ID is reserved
     this.memo(e, ctx);
@@ -92,7 +93,7 @@ export class Crud<E> {
   }
 
   async read(ctx: Context, id?: string | string[]) {
-    console.log(`Calling ${this.entity?.name ?? ''} ${this.dest} read`);
+    logger.info(`Calling ${this.entity?.name ?? ''} ${this.dest} read`);
     const entityId = this.entityId ?? ((_e: E) => { return 'What?'; });
     if (id) {
       const dest = this.dest ?? 'What?';
@@ -117,7 +118,7 @@ export class Crud<E> {
         if (missing.length === 0) {
           return vals;
         }
-        console.log(`Partial cache hit for ${this.entity?.name ?? ''} ${this.dest}`);
+        logger.info(`Partial cache hit for ${this.entity?.name ?? ''} ${this.dest}`);
         // TODO: is it possible that `missingVals` it is unaligned with `missing`??
         const missingVals = (this.memo(await this.readFn(ctx, missing), ctx, missing) as E[]).sort(
           (a: E, b: E) => missing.indexOf(entityId(a)) - missing.indexOf(entityId(b))
@@ -143,10 +144,10 @@ export class Crud<E> {
         ctx.memo[dest] = ctx.memo[dest] ?? {};
         ctx.memo[dest][entityName] = ctx.memo[dest][entityName] ?? {};
         if (!ctx.memo[dest][entityName][id]) {
-          console.log(`Cache miss for ${this.entity?.name ?? ''} ${this.dest}`);
+          logger.info(`Cache miss for ${this.entity?.name ?? ''} ${this.dest}`);
           ctx.memo[dest][entityName][id] = new (this.entity as new () => E)();
         } else {
-          console.log(`Cache hit for ${this.entity?.name ?? ''} ${this.dest}`);
+          logger.info(`Cache hit for ${this.entity?.name ?? ''} ${this.dest}`);
           return ctx.memo[dest][entityName][id];
         }
         // Linter thinks this is shadowing the other one on line 152 because JS hoisting nonsense
@@ -171,7 +172,7 @@ export class Crud<E> {
         }
       }
     }
-    console.log(`Full cache miss for ${this.entity?.name ?? ''} ${this.dest}`);
+    logger.info(`Full cache miss for ${this.entity?.name ?? ''} ${this.dest}`);
     const out = await this.readFn(ctx);
     if (!out || out.length === 0) {
       // Don't memo in this case, just pass it through
@@ -182,13 +183,13 @@ export class Crud<E> {
   }
 
   async update(e: E | E[], ctx: Context) {
-    console.log(`Calling ${this.entity?.name ?? ''} ${this.dest} update`);
+    logger.info(`Calling ${this.entity?.name ?? ''} ${this.dest} update`);
     const es = Array.isArray(e) ? e : [e];
     return this.memo(await this.updateFn(es, ctx), ctx, e);
   }
 
   async delete(e: E | E[], ctx: Context) {
-    console.log(`Calling ${this.entity?.name ?? ''} ${this.dest} delete`);
+    logger.info(`Calling ${this.entity?.name ?? ''} ${this.dest} delete`);
     const es = Array.isArray(e) ? e : [e];
     const out = await this.deleteFn(es, ctx);
     this.unmemo(es, ctx); // Remove deleted record(s) from the memo

--- a/src/router/db.ts
+++ b/src/router/db.ts
@@ -69,7 +69,7 @@ db.post('/attach', async (req, res) => {
 
 // TODO revive and test
 /*db.post('/import', async (req, res) => {
-  console.log('Calling /import');
+  logger.info('Calling /import');
   const {dump, dbAlias, awsRegion, awsAccessKeyId, awsSecretAccessKey} = req.body;
   if (!dump || !dbAlias || !awsRegion || !awsAccessKeyId || !awsSecretAccessKey) return res.status(400).json(
     `Required key(s) not provided: ${[

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -259,13 +259,13 @@ export async function dump(dbAlias: string, uid: any, dataOnly: boolean) {
 ) {
   let conn1, conn2, dbId, dbUser;
   try {
-    console.log('Creating account for user...');
+    logger.info('Creating account for user...');
     const dbGen = dbMan.genUserAndPass();
     dbUser = dbGen[0];
     const dbPass = dbGen[1];
     const meta = await dbMan.setMetadata(dbAlias, dbUser, user);
     dbId = meta.dbId;
-    console.log('Establishing DB connections...');
+    logger.info('Establishing DB connections...');
     conn1 = await createConnection(dbMan.baseConnConfig);
     await conn1.query(`CREATE DATABASE ${dbId};`);
     conn2 = await createConnection({
@@ -275,7 +275,7 @@ export async function dump(dbAlias: string, uid: any, dataOnly: boolean) {
     });
     // Restore dump and wrap it in a try catch
     // that drops the database on error
-    console.log('Restoring schema and data from dump...');
+    logger.info('Restoring schema and data from dump...');
     await conn2.query(dumpStr);
     // Update aws_account schema
     await conn2.query(`
@@ -286,7 +286,7 @@ export async function dump(dbAlias: string, uid: any, dataOnly: boolean) {
     // Grant permissions
     await conn2.query(dbMan.newPostgresRoleQuery(dbUser, dbPass, dbId));
     await conn2.query(dbMan.grantPostgresRoleQuery(dbUser));
-    console.log('Done!');
+    logger.info('Done!');
     return {
       alias: dbAlias,
       id: dbId,

--- a/test/common/simple-integration.ts
+++ b/test/common/simple-integration.ts
@@ -1,5 +1,7 @@
 import { execSync, } from 'child_process'
 
+import logger from '../../src/services/logger'
+
 jest.setTimeout(30000);
 
 // Could use $() but requires nasty escaping
@@ -14,10 +16,10 @@ beforeAll(() => {
 
 afterAll(() => {
   // Dump the logs for potential debugging
-  console.log('Engine logs');
-  console.log(execSync('docker logs iasql-engine_change_engine_1', { encoding: 'utf8', }));
-  console.log('Postgres logs');
-  console.log(execSync('docker logs iasql-engine_postgresql_1', { encoding: 'utf8', }));
+  logger.info('Engine logs');
+  logger.info(execSync('docker logs iasql-engine_change_engine_1', { encoding: 'utf8', }));
+  logger.info('Postgres logs');
+  logger.info(execSync('docker logs iasql-engine_postgresql_1', { encoding: 'utf8', }));
   // Terminate the docker container
   execSync('docker stop $(docker ps -q)');
 });


### PR DESCRIPTION
Debugging what's going wrong with a test is hard right now because Jest's console.log takeover code makes it ridiculously hard to read the log output. So I've bypassed it using `process.[stdout|stderr].write` directly. Just take a look at the log output of the tests in *this* PR to see the massive improvement