### PR TITLE
Fix gen-module by running migrations in dep order ourselves

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,7 +5,6 @@ import { ConfigInterface, throwError, } from './config';
 if (!['production', 'staging', 'local', 'test'].includes(process.env.IASQL_ENV ?? '')) throwError(
   `Invalid environment ${process.env.IASQL_ENV}`
 );
-console.log(`Using IASQL_ENV: ${process.env.IASQL_ENV}`);
 // tslint:disable-next-line:no-var-requires
 const config: ConfigInterface = require(`./${process.env.IASQL_ENV}`).default;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,3 +60,5 @@ MetadataRepo.init().then(() => {
     });
   })
 });
+
+logger.info(`Using IASQL_ENV: ${process.env.IASQL_ENV}`);

--- a/src/modules/iasql_platform@0.0.1/migration/1649298097680-iasql_platform.ts
+++ b/src/modules/iasql_platform@0.0.1/migration/1649298097680-iasql_platform.ts
@@ -1,7 +1,7 @@
 import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class iasqlPlatform1649177125087 implements MigrationInterface {
-    name = 'iasqlPlatform1649177125087'
+export class iasqlPlatform1649298097680 implements MigrationInterface {
+    name = 'iasqlPlatform1649298097680'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TABLE "iasql_module" ("name" character varying NOT NULL, CONSTRAINT "UQ_e91a0b0e9a029428405fdd17ee4" UNIQUE ("name"), CONSTRAINT "PK_e91a0b0e9a029428405fdd17ee4" PRIMARY KEY ("name"))`);

--- a/src/scripts/list-deps.ts
+++ b/src/scripts/list-deps.ts
@@ -1,0 +1,27 @@
+import * as Modules from '../modules'
+import { Module, } from '../modules/interfaces'
+
+const moduleName = process.argv[process.argv.length - 1];
+
+const depModules: { [key: string]: Module, } = {};
+
+const getModule = (name: string) => (Object.values(Modules) as Module[])
+  .find((m: Module) => name === `${m.name}@${m.version}`);
+
+const processDep = (dep: string) => {
+  const depMod = getModule(dep);
+  if (!depMod) {
+    throw new Error(`Could not find dependency ${dep}`);
+  }
+  depModules[dep] = depMod;
+  depMod.dependencies.forEach(processDep);
+};
+
+processDep(moduleName);
+
+// TODO: Remove this hackery once typeorm migration doesn't do weird alter table crap
+if (moduleName !== 'iasql_platform@0.0.1') {
+  delete depModules['iasql_platform@0.0.1'];
+}
+
+console.log(Object.keys(depModules).join(':'));

--- a/src/scripts/migrate-dep-order.ts
+++ b/src/scripts/migrate-dep-order.ts
@@ -1,0 +1,55 @@
+import * as Modules from '../modules'
+import { Module, } from '../modules/interfaces'
+import { sortModules, } from '../services/mod-sort'
+import { TypeormWrapper, } from '../services/typeorm'
+
+const moduleName = process.argv[process.argv.length - 1];
+
+const depModules: { [key: string]: Module, } = {};
+
+const getModule = (name: string) => (Object.values(Modules) as Module[])
+  .find((m: Module) => name === `${m.name}@${m.version}`);
+
+const rootModule = getModule(moduleName);
+
+if (!rootModule) {
+  throw new Error(`Could not find module ${moduleName}`); 
+}
+
+const processDep = (dep: string) => {
+  const depMod = getModule(dep);
+  if (!depMod) {
+    throw new Error(`Could not find dependency ${dep}`);
+  }
+  depModules[dep] = depMod;
+  depMod.dependencies.forEach(processDep);
+};
+
+rootModule.dependencies.forEach(processDep);
+
+let sortedDeps = sortModules(Object.values(depModules), []);
+
+// TODO: Remove this hackery once typeorm migration doesn't do weird alter table crap
+if (moduleName !== 'iasql_platform@0.0.1') {
+  sortedDeps = sortedDeps.filter(d => d.name !== 'iasql_platform');
+}
+
+const entities = sortedDeps.map(d => d.provides.entities).flat();
+
+(async () => {
+  const conn = await TypeormWrapper.createConn('__example__', {
+    entities,
+    host: 'localhost',
+    username: 'postgres',
+    password: 'test',
+  });
+
+  const qr = conn.createQueryRunner();
+
+  for (const dep of sortedDeps) {
+    console.log(`Adding ${dep.name}...`);
+    await dep.migrations.install(qr);
+  }
+  console.log('Done!');
+  process.exit(0);
+})();

--- a/src/scripts/migrate-dep-order.ts
+++ b/src/scripts/migrate-dep-order.ts
@@ -13,7 +13,7 @@ const getModule = (name: string) => (Object.values(Modules) as Module[])
 const rootModule = getModule(moduleName);
 
 if (!rootModule) {
-  throw new Error(`Could not find module ${moduleName}`); 
+  throw new Error(`Could not find module ${moduleName}`);
 }
 
 const processDep = (dep: string) => {


### PR DESCRIPTION
This updates `gen-module` to use our own logic for module ordering and runs the migrations in that order.

Despite that, there's still some weirdness with `iasql_platform` that I have been able to confirm happens even using TypeORM's migration run and generate code the "proper" way when I blew away all modules besides that one and `aws_account` and *still* got weird pollution from it. It appears to be a regression of some sort in TypeORM because it didn't happen before. I'm thinking of making a simple repo to minimally reproduce the issue and reporting it to TypeORM so I can hopefully remove the weird hackery in my scripts around the `iasql_platform` module.