### PR TITLE
properly remove db from metadatarepo on disconnect

### DIFF
--- a/src/services/repositories/metadata.ts
+++ b/src/services/repositories/metadata.ts
@@ -93,7 +93,7 @@ class MetadataRepo {
     // remove entry from the join table
     await this.userRepo.save(user);
     // remove entry
-    await this.dbRepo.delete(dbToDel);
+    await this.dbRepo.remove(dbToDel);
   }
 
   async updateDbStatus(a0Id: string, dbAlias: string, status: boolean) {

--- a/test/common/metadata.ts
+++ b/test/common/metadata.ts
@@ -8,7 +8,7 @@ jest.setTimeout(240000);
 beforeAll(async () => await execComposeUp());
 afterAll(async () => await execComposeDown());
 
-describe('Testing failure path', () => {
+describe('Testing metadata repo', () => {
   it('creates a new test db', (done) => void iasql.connect(
     dbAlias,
     process.env.AWS_REGION ?? 'barf',
@@ -16,7 +16,7 @@ describe('Testing failure path', () => {
     process.env.AWS_SECRET_ACCESS_KEY ?? 'barf',
     'not-needed', 'not-needed').then(...finish(done)));
 
-  it('check row iasql database exists', query(`
+  it('check row in iasql database table exists', query(`
     SELECT *
     FROM iasql_database
     WHERE pg_name = '${dbAlias}';

--- a/test/common/metadata.ts
+++ b/test/common/metadata.ts
@@ -1,0 +1,47 @@
+import * as iasql from '../../src/services/iasql'
+import { runQuery, finish, execComposeUp, execComposeDown } from '../helpers'
+
+const query = runQuery.bind(null, 'iasql_metadata');
+const dbAlias = 'metadatatest';
+
+jest.setTimeout(240000);
+beforeAll(async () => await execComposeUp());
+afterAll(async () => await execComposeDown());
+
+describe('Testing failure path', () => {
+  it('creates a new test db', (done) => void iasql.connect(
+    dbAlias,
+    process.env.AWS_REGION ?? 'barf',
+    process.env.AWS_ACCESS_KEY_ID ?? 'barf',
+    process.env.AWS_SECRET_ACCESS_KEY ?? 'barf',
+    'not-needed', 'not-needed').then(...finish(done)));
+
+  it('check row iasql database exists', query(`
+    SELECT *
+    FROM iasql_database
+    WHERE pg_name = '${dbAlias}';
+  `, (row: any[]) => expect(row.length).toBe(1)));
+
+  it('check row in join table exists', query(`
+    SELECT *
+    FROM iasql_user_databases
+    WHERE iasql_database_pg_name = '${dbAlias}';
+  `, (row: any[]) => expect(row.length).toBe(1)));
+
+  it('deletes the test db', (done) => void iasql
+    .disconnect(dbAlias, 'not-needed')
+    .then(...finish(done)));
+
+  it('check there is no row in iasql database', query(`
+    SELECT *
+    FROM iasql_database
+    WHERE pg_name = '${dbAlias}';
+  `, (row: any[]) => expect(row.length).toBe(0)));
+
+  it('check there is no row in join table', query(`
+    SELECT *
+    FROM iasql_user_databases
+    WHERE iasql_database_pg_name = '${dbAlias}';
+  `, (row: any[]) => expect(row.length).toBe(0)));
+});
+

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -47,17 +47,17 @@ export function runUninstall(dbAlias: string, mods: string[]) {
   return runQuery(dbAlias, `select iasql_uninstall(${mods.map(m => `'${m}'`)});`);
 }
 
-export function runQuery(dbAlias: string, queryString: string, assertFn?: (res: any[]) => void) {
+export function runQuery(databaseName: string, queryString: string, assertFn?: (res: any[]) => void) {
   return function (done: (e?: any) => {}) {
     logger.info(queryString);
     createConnection({
-      name: dbAlias,
+      name: `${databaseName}-conn`,
       type: 'postgres',
       username: 'postgres',
       password: 'test',
       host: 'localhost',
       port: 5432,
-      database: dbAlias,
+      database: databaseName,
       extra: { ssl: false, },
     }).then((conn) => {
       conn.query(queryString).then((res: any[]) => {


### PR DESCRIPTION
This also fixes an error in the scheduler bootstrapping in which it doesn't find already disconnected databases as described in the metadata repo.