### PR TITLE
Fixes for postgraphile in staging, and enable production

### DIFF
--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -25,7 +25,10 @@ const config: ConfigInterface = {
   },
   telemetry: {
     amplitudeKey: '968524573d0f8bd2e84460099bca9353'
-  }
+  },
+  graphql: {
+    withGraphiql: false,
+  },
 };
 
 export default config;

--- a/src/router/graphql.ts
+++ b/src/router/graphql.ts
@@ -29,7 +29,7 @@ if (config.graphql) {
     postgraphiles[db] = postgraphiles[db] ?? {
       lastAccessMs: Date.now(),
       graphile: postgraphile(
-        `postgresql://${config.db.user}:${config.db.password}@${config.db.host}/${db}${config.db.forceSSL ? '?sslmode=require' : ''}`,
+        `postgresql://${config.db.user}:${config.db.password}@${config.db.host}/${db}${config.db.forceSSL ? '?sslmode=no-verify' : ''}`,
         'public',
         {
           externalUrlBase: `/v1/graphql/${db}`,


### PR DESCRIPTION
Before landing my dashboard change to allow module management in the GUI, I deployed the branch to staging and noticed that I could crash the engine, so this is the fix.

- Fix sslmode for postgraphile
- Enable in production now that it was verified with staging
