### PR TITLE
Implement facsimile of the Alan module system to reduce relative path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
+    "iasql": "link:./src",
     "@amplitude/node": "^1.10.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.76.0",
     "@aws-sdk/client-ec2": "^3.67.0",

--- a/src/modules/0.0.1/aws_account/entity/aws_account.ts
+++ b/src/modules/0.0.1/aws_account/entity/aws_account.ts
@@ -3,8 +3,7 @@ import {
   Entity,
   PrimaryGeneratedColumn,
 } from 'typeorm'
-
-import { cloudId, } from '../../../../services/cloud-id' // This is ridiculous. Can we fix this?
+import { cloudId, } from 'iasql/services/cloud-id'
 
 @Entity({
   name: 'aws_account',

--- a/src/modules/0.0.1/aws_account/index.ts
+++ b/src/modules/0.0.1/aws_account/index.ts
@@ -1,8 +1,7 @@
 import { In, } from 'typeorm'
-
-import { AWS, } from '../../../services/gateways/aws'
+import { AWS, } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
 import { AwsAccountEntity, } from './entity'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
 import * as metadata from './module.json'
 
 export const AwsAccount: Module = new Module({

--- a/src/modules/0.0.1/aws_cloudwatch/entity/log_group.ts
+++ b/src/modules/0.0.1/aws_cloudwatch/entity/log_group.ts
@@ -3,8 +3,7 @@ import {
   PrimaryColumn,
   Column,
 } from 'typeorm'
-
-import { cloudId, } from '../../../../services/cloud-id'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 @Entity()
 export class LogGroup {

--- a/src/modules/0.0.1/aws_cloudwatch/index.ts
+++ b/src/modules/0.0.1/aws_cloudwatch/index.ts
@@ -1,5 +1,6 @@
-import { AWS, } from '../../../services/gateways/aws'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
+import { AWS, } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
+
 import { LogGroup } from './entity'
 import * as metadata from './module.json'
 

--- a/src/modules/0.0.1/aws_ec2/entity/instance.ts
+++ b/src/modules/0.0.1/aws_ec2/entity/instance.ts
@@ -8,10 +8,10 @@ import {
   ManyToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { cloudId, } from 'iasql/services/cloud-id'
 
 // TODO: Is there a better way to deal with cross-module entities?
 import { SecurityGroup, } from '../../aws_security_group/entity';
-import { cloudId, } from '../../../../services/cloud-id'
 
 // TODO complete instance schema
 @Entity()

--- a/src/modules/0.0.1/aws_ec2/index.ts
+++ b/src/modules/0.0.1/aws_ec2/index.ts
@@ -1,9 +1,9 @@
 import { Instance as InstanceAWS, } from '@aws-sdk/client-ec2'
+import { AWS, IASQL_EC2_TAG_NAME } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
 
-import { Instance, } from './entity'
 import { AwsSecurityGroupModule, } from '../aws_security_group'
-import { AWS, IASQL_EC2_TAG_NAME } from '../../../services/gateways/aws'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
+import { Instance, } from './entity'
 import * as metadata from './module.json'
 
 export const AwsEc2Module: Module = new Module({

--- a/src/modules/0.0.1/aws_ecr/entity/public_repository.ts
+++ b/src/modules/0.0.1/aws_ecr/entity/public_repository.ts
@@ -1,6 +1,5 @@
 import { Entity, PrimaryColumn, Column, } from 'typeorm'
-
-import { cloudId, } from '../../../../services/cloud-id'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 @Entity()
 export class PublicRepository {

--- a/src/modules/0.0.1/aws_ecr/entity/repository.ts
+++ b/src/modules/0.0.1/aws_ecr/entity/repository.ts
@@ -1,6 +1,5 @@
 import { Entity, PrimaryColumn, Column, } from 'typeorm'
-
-import { cloudId, } from '../../../../services/cloud-id'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 export enum ImageTagMutability {
   IMMUTABLE = "IMMUTABLE",

--- a/src/modules/0.0.1/aws_ecs_fargate/entity/cluster.ts
+++ b/src/modules/0.0.1/aws_ecs_fargate/entity/cluster.ts
@@ -3,8 +3,7 @@ import {
   Entity,
   PrimaryColumn,
 } from 'typeorm'
-
-import { cloudId, } from '../../../../services/cloud-id'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 @Entity()
 export class Cluster {

--- a/src/modules/0.0.1/aws_ecs_fargate/entity/service.ts
+++ b/src/modules/0.0.1/aws_ecs_fargate/entity/service.ts
@@ -10,11 +10,11 @@ import {
   ManyToOne,
   PrimaryColumn,
 } from 'typeorm'
+import { cloudId, } from 'iasql/services/cloud-id'
 
-import { Cluster, TaskDefinition, ContainerDefinition } from '.';
+import { Cluster, TaskDefinition, } from '.';
 import { TargetGroup } from '../../aws_elb/entity';
 import { SecurityGroup } from '../../aws_security_group/entity';
-import { cloudId, } from '../../../../services/cloud-id'
 
 export enum AssignPublicIp {
   DISABLED = "DISABLED",

--- a/src/modules/0.0.1/aws_ecs_fargate/entity/task_definition.ts
+++ b/src/modules/0.0.1/aws_ecs_fargate/entity/task_definition.ts
@@ -9,9 +9,9 @@ import {
   JoinColumn,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { cloudId, } from 'iasql/services/cloud-id'
 
 import { ContainerDefinition } from '.';
-import { cloudId, } from '../../../../services/cloud-id'
 import { Role, } from '../../aws_iam/entity';
 
 export enum TaskDefinitionStatus {

--- a/src/modules/0.0.1/aws_ecs_fargate/index.ts
+++ b/src/modules/0.0.1/aws_ecs_fargate/index.ts
@@ -1,4 +1,7 @@
-import { AWS, } from '../../../services/gateways/aws'
+import { AWS, } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
+import logger from 'iasql/services/logger'
+
 import {
   Cluster,
   ContainerDefinition,
@@ -6,10 +9,8 @@ import {
   Service,
   TaskDefinition,
 } from './entity'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
 import { AwsEcrModule, AwsElbModule, AwsIamModule, AwsSecurityGroupModule, AwsCloudwatchModule } from '..'
 import * as metadata from './module.json'
-import logger from '../../../services/logger'
 
 export const AwsEcsFargateModule: Module = new Module({
   ...metadata,

--- a/src/modules/0.0.1/aws_elb/entity/listener.ts
+++ b/src/modules/0.0.1/aws_elb/entity/listener.ts
@@ -6,10 +6,10 @@ import {
   PrimaryGeneratedColumn,
   Unique,
 } from 'typeorm'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 import { LoadBalancer, } from './load_balancer'
 import { TargetGroup, ProtocolEnum, } from './target_group'
-import { cloudId, } from '../../../../services/cloud-id'
 
 export enum ActionTypeEnum {
   // AUTHENTICATE_COGNITO = "authenticate-cognito",

--- a/src/modules/0.0.1/aws_elb/entity/load_balancer.ts
+++ b/src/modules/0.0.1/aws_elb/entity/load_balancer.ts
@@ -10,10 +10,10 @@ import {
   ManyToOne,
   PrimaryColumn,
 } from 'typeorm'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 import { SecurityGroup, } from '../../aws_security_group/entity'
 import { Vpc, } from '../../aws_vpc/entity'
-import { cloudId, } from '../../../../services/cloud-id'
 
 export enum LoadBalancerSchemeEnum {
   INTERNAL = "internal",

--- a/src/modules/0.0.1/aws_elb/entity/target_group.ts
+++ b/src/modules/0.0.1/aws_elb/entity/target_group.ts
@@ -8,8 +8,8 @@ import {
   ManyToOne,
   PrimaryColumn,
 } from 'typeorm'
+import { cloudId, } from 'iasql/services/cloud-id'
 
-import { cloudId, } from '../../../../services/cloud-id'
 import { Vpc, } from '../../aws_vpc/entity'
 
 export enum TargetTypeEnum {

--- a/src/modules/0.0.1/aws_elb/index.ts
+++ b/src/modules/0.0.1/aws_elb/index.ts
@@ -3,8 +3,9 @@ import {
   Listener as ListenerAws,
   LoadBalancer as LoadBalancerAws,
 } from '@aws-sdk/client-elastic-load-balancing-v2'
+import { AWS, } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
 
-import { AWS, } from '../../../services/gateways/aws'
 import {
   ActionTypeEnum,
   Listener,
@@ -20,7 +21,6 @@ import {
   TargetTypeEnum,
 } from './entity'
 import { AwsVpcModule, } from '../aws_vpc'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
 import { AwsSecurityGroupModule } from '..'
 import * as metadata from './module.json'
 

--- a/src/modules/0.0.1/aws_iam/entity/role.ts
+++ b/src/modules/0.0.1/aws_iam/entity/role.ts
@@ -3,8 +3,7 @@ import {
   Entity,
   PrimaryColumn,
 } from 'typeorm';
-
-import { cloudId, } from '../../../../services/cloud-id'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 // TODO complete schema
 @Entity()

--- a/src/modules/0.0.1/aws_iam/index.ts
+++ b/src/modules/0.0.1/aws_iam/index.ts
@@ -1,8 +1,8 @@
 import { Role as AWSRole } from '@aws-sdk/client-iam'
+import { AWS, } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
 
 import { Role } from './entity'
-import { AWS, } from '../../../services/gateways/aws'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
 import * as metadata from './module.json'
 
 export const AwsIamModule: Module = new Module({

--- a/src/modules/0.0.1/aws_rds/entity/rds.ts
+++ b/src/modules/0.0.1/aws_rds/entity/rds.ts
@@ -5,9 +5,9 @@ import {
   ManyToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 import { SecurityGroup, } from '../../aws_security_group/entity'
-import { cloudId, } from '../../../../services/cloud-id'
 
 @Entity()
 export class RDS {

--- a/src/modules/0.0.1/aws_rds/index.ts
+++ b/src/modules/0.0.1/aws_rds/index.ts
@@ -1,8 +1,8 @@
 import { ModifyDBInstanceCommandInput } from '@aws-sdk/client-rds'
+import { AWS, } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
 
-import { AWS, } from '../../../services/gateways/aws'
 import { RDS, } from './entity'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
 import { AwsSecurityGroupModule } from '..'
 import * as metadata from './module.json'
 

--- a/src/modules/0.0.1/aws_route53_hosted_zones/entity/hosted_zone.ts
+++ b/src/modules/0.0.1/aws_route53_hosted_zones/entity/hosted_zone.ts
@@ -3,8 +3,7 @@ import {
   Entity,
   PrimaryGeneratedColumn,
 } from 'typeorm'
-
-import { cloudId, } from '../../../../services/cloud-id'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 @Entity()
 export class HostedZone {

--- a/src/modules/0.0.1/aws_route53_hosted_zones/index.ts
+++ b/src/modules/0.0.1/aws_route53_hosted_zones/index.ts
@@ -1,6 +1,7 @@
 import { ResourceRecordSet as AwsResourceRecordSet } from '@aws-sdk/client-route-53'
-import { AWS, } from '../../../services/gateways/aws'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
+import { AWS, } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
+
 import { HostedZone } from './entity'
 import { RecordType, ResourceRecordSet } from './entity/resource_records_set';
 import * as metadata from './module.json'

--- a/src/modules/0.0.1/aws_security_group/entity/index.ts
+++ b/src/modules/0.0.1/aws_security_group/entity/index.ts
@@ -10,8 +10,8 @@ import {
   PrimaryGeneratedColumn,
   Unique,
 } from 'typeorm'
+import { cloudId, } from 'iasql/services/cloud-id'
 
-import { cloudId, } from '../../../../services/cloud-id'
 import { Vpc } from '../../aws_vpc/entity';
 
 @Entity()

--- a/src/modules/0.0.1/aws_security_group/index.ts
+++ b/src/modules/0.0.1/aws_security_group/index.ts
@@ -1,12 +1,12 @@
 import { In, } from 'typeorm'
+import { AWS, } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
+import logger from 'iasql/services/logger'
 
-import { AWS, } from '../../../services/gateways/aws'
 import { SecurityGroup, SecurityGroupRule, } from './entity'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
 import * as metadata from './module.json'
 import { AwsVpcModule } from '../aws_vpc'
 import { Vpc } from '../aws_vpc/entity'
-import logger from '../../../services/logger'
 
 export const AwsSecurityGroupModule: Module = new Module({
   ...metadata,

--- a/src/modules/0.0.1/aws_vpc/entity/index.ts
+++ b/src/modules/0.0.1/aws_vpc/entity/index.ts
@@ -6,8 +6,7 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm'
-
-import { cloudId, } from '../../../../services/cloud-id'
+import { cloudId, } from 'iasql/services/cloud-id'
 
 export enum VpcState {
   AVAILABLE = 'available',

--- a/src/modules/0.0.1/aws_vpc/index.ts
+++ b/src/modules/0.0.1/aws_vpc/index.ts
@@ -1,6 +1,7 @@
 import { Subnet as AwsSubnet, Vpc as AwsVpc, } from '@aws-sdk/client-ec2'
+import { AWS, } from 'iasql/services/gateways/aws'
+import { Context, Crud, Mapper, Module, } from 'iasql/modules'
 
-import { AWS, } from '../../../services/gateways/aws'
 import {
   AvailabilityZone,
   Subnet,
@@ -8,7 +9,6 @@ import {
   SubnetState,
   VpcState,
 } from './entity'
-import { Context, Crud, Mapper, Module, } from '../../interfaces'
 import * as metadata from './module.json'
 
 export const AwsVpcModule: Module = new Module({

--- a/src/modules/0.0.1/iasql_functions/index.ts
+++ b/src/modules/0.0.1/iasql_functions/index.ts
@@ -1,6 +1,6 @@
 /* THIS MODULE IS A SPECIAL SNOWFLAKE. DON'T LOOK AT IT FOR HOW TO WRITE A REAL MODULE */
 
-import { Module, } from '../../interfaces'
+import { Module, } from 'iasql/modules'
 import * as metadata from './module.json'
 
 export const IasqlFunctions: Module = new Module({

--- a/src/modules/0.0.1/iasql_platform/index.ts
+++ b/src/modules/0.0.1/iasql_platform/index.ts
@@ -1,6 +1,6 @@
 /* THIS MODULE IS A SPECIAL SNOWFLAKE. DON'T LOOK AT IT FOR HOW TO WRITE A REAL MODULE */
 
-import { Module, } from '../../interfaces'
+import { Module, } from 'iasql/modules'
 import * as metadata from './module.json'
 
 export const IasqlPlatform: Module = new Module({

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -2,8 +2,8 @@ import fs from 'fs'
 
 import { In, QueryRunner, getMetadataArgsStorage, } from 'typeorm'
 
-import { getCloudId, } from '../services/cloud-id'
-import logger from '../services/logger'
+import { getCloudId, } from 'iasql/services/cloud-id'
+import logger from 'iasql/services/logger'
 
 // The exported interfaces are meant to provide better type checking both at compile time and in the
 // editor. They *shouldn't* have to be ever imported directly, only the classes ought to be, but as

--- a/yarn.lock
+++ b/yarn.lock
@@ -3197,6 +3197,10 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+"iasql@link:./src":
+  version "0.0.0"
+  uid ""
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
# `..` dashed!

I got super annoyed by all of the relative path mangling in the prior PR when I moved the modules another level deep in the git tree, especially since [we came up with a superior system for Alan that would've avoided it](https://docs.alan-lang.org/module_resolution.html), so like any sane person I decided to do those tedious changes a second time!

But I figured out a trick with yarn's `link:` syntax to give myself a named alias to the `src/` directory, which I called `iasql`. So now if I want the config I can write `import config from 'iasql/config'` anywhere in the codebase and it'll work, for instance.

This was a really quick change and there's no one here to stop me today! Mwahahaha