### PR TITLE
Make the latest module version configurable

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,6 +3,9 @@ export interface ConfigInterface {
   http: {
     port: number;
   };
+  modules: {
+    latestVersion: string; // Which version of the modules should be considered latest
+  };
   // Configuration for the postgres database
   db: {
     host: string;

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -4,6 +4,9 @@ const config: ConfigInterface = {
   http: {
     port: 8088,
   },
+  modules: {
+    latestVersion: '0.0.3',
+  },
   db: {
     host: 'postgresql',
     user: 'postgres',

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -4,6 +4,9 @@ const config: ConfigInterface = {
   http: {
     port: 8088,
   },
+  modules: {
+    latestVersion: '0.0.2',
+  },
   db: {
     host: 'db.iasql.com',
     // TODO: Move away from env var to secrets

--- a/src/config/staging.ts
+++ b/src/config/staging.ts
@@ -4,6 +4,9 @@ const config: ConfigInterface = {
   http: {
     port: 8088,
   },
+  modules: {
+    latestVersion: '0.0.3',
+  },
   db: {
     host: 'db-staging.iasql.com',
     // TODO: Move away from env var to secret

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -4,6 +4,9 @@ const config: ConfigInterface = {
   http: {
     port: 8088,
   },
+  modules: {
+    latestVersion: '0.0.3',
+  },
   db: {
     host: 'localhost',
     user: 'postgres',

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,5 +1,8 @@
+import config from '../config'
+
+export const latest = require(`./${config.modules.latestVersion}`);
+
 export * as v0_0_1 from './0.0.1'
 export * as v0_0_2 from './0.0.2'
 export * as v0_0_3 from './0.0.3'
-export * as latest from './0.0.3' // Double-exported, but simplifies connect
 export * from './interfaces'

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,5 +1,8 @@
 import config from '../config'
 
+// No good way to re-export a require without this, and no way to determine what to import by the
+// config variable without require
+// tslint:disable-next-line:no-var-requires
 export const latest = require(`./${config.modules.latestVersion}`);
 
 export * as v0_0_1 from './0.0.1'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -25,6 +25,6 @@ if (config.auth) {
 // TODO secure with scope
 v1.use('/db', db);
 if (config.graphql) v1.use('/graphql', graphql);
-v1.get('/version', (_req, res) => res.send('0.0.3')); // TODO: DRY this somehow
+v1.get('/version', (_req, res) => res.send(config.modules.latestVersion));
 
 export { v1 };


### PR DESCRIPTION
As discussed offline, this change lets us deploy production without releasing the in-development modules for end users, but lets us do so in the staging environment for end-to-end testing.