### PR TITLE
Remove console.log from where it doesn't belong

### DIFF
--- a/src/services/gateways/aws.ts
+++ b/src/services/gateways/aws.ts
@@ -389,7 +389,7 @@ export class AWS {
         const regionAZs = await client.send(new DescribeAvailabilityZonesCommand({ AllAvailabilityZones: true, }));
         availabilityZones = availabilityZones.concat(regionAZs.AvailabilityZones ?? []);
       } catch (e) {
-        console.log(`Could not get availability zones for region: ${region}. Error: ${e}`);
+        logger.info(`Could not get availability zones for region: ${region}. Error: ${e}`);
       }
     }
     return availabilityZones;

--- a/src/services/typeorm.ts
+++ b/src/services/typeorm.ts
@@ -68,9 +68,6 @@ export class TypeormWrapper {
       ...connectionConfig as PostgresConnectionOptions,
       database,
     };
-    console.log({
-      connOpts,
-    });
     const versionString = await TypeormWrapper.getVersionString(database);
     const Modules = (AllModules as any)[versionString];
     // Grab all of the entities and create the TypeORM connection with it. Theoretically only need
@@ -82,12 +79,10 @@ export class TypeormWrapper {
       .map((m: any) => Object.values(m.provides.entities))
       .flat()
       .filter(e => typeof e === 'function') as Function[];
-    console.log({ entities, })
 
     // Now that we have the entities for this database, close the temporary connection and create
     // the real connection with the entities present
     const name = uuidv4();
-    console.log({ ...connOpts, entities, name, });
     typeorm.connection = await createConnection({ ...connOpts, entities, name, });
     return typeorm;
   }

--- a/test/modules/aws-route53-hosted-zones-integration.ts
+++ b/test/modules/aws-route53-hosted-zones-integration.ts
@@ -1,5 +1,6 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql'
+import logger from '../../src/services/logger'
 import { getPrefix, runQuery, runInstall, runUninstall, runApply, finish, execComposeUp, execComposeDown, runSync, } from '../helpers'
 
 const prefix = getPrefix();
@@ -174,8 +175,8 @@ describe('Route53 Integration Testing', () => {
     INNER JOIN hosted_zone ON hosted_zone.id = parent_hosted_zone_id
     WHERE domain_name = '${replaceDomainName}';
   `, (res: any[]) => {
-    console.log(`${JSON.stringify(res)}`)
-    const multiline = res.find(r => {console.log(JSON.stringify(r)); return r.name === resourceRecordSetMultilineName && r.record_type === resourceRecordSetTypeA});
+    logger.info(`${JSON.stringify(res)}`)
+    const multiline = res.find(r => {logger.info(JSON.stringify(r)); return r.name === resourceRecordSetMultilineName && r.record_type === resourceRecordSetTypeA});
     expect(multiline).toBeDefined();  
     expect(multiline?.record?.split('\n').length).toBe(2);
     return expect(res.length).toBe(4);
@@ -197,7 +198,7 @@ describe('Route53 Integration Testing', () => {
     WHERE domain_name = '${replaceDomainName}';
   `, (res: any[]) => {
     const updated = res.find(r => r.name === resourceRecordSetMultilineNameReplace && r.record_type === resourceRecordSetTypeA);
-    console.log(JSON.stringify(updated))
+    logger.info(JSON.stringify(updated))
     expect(updated).toBeDefined();
     expect(updated.record_type).toBe(resourceRecordSetTypeA);
     return expect(res.length).toBe(4); 


### PR DESCRIPTION
I realized that I had accidentally left some debug logs in one of my PRs, so I decided to remove them, but I also noticed a few legacy uses of `console.log` where it doesn't belong and fixed that. (The only places `console.log` should be allowed is in the `logger.ts` file which should be relatively obvious, and in the `scripts` as those files unfortunately cannot have a dependency on the `config`, at least at the moment)