### PR TITLE
Fix security group mapper

### DIFF
--- a/src/modules/0.0.3/aws_security_group/index.ts
+++ b/src/modules/0.0.3/aws_security_group/index.ts
@@ -139,7 +139,7 @@ export const AwsSecurityGroupModule: Module = new Module({
             relations,
           } : { relations, };
           const securityGroups = await ctx.orm.find(SecurityGroup, opts);
-          securityGroups.map(async (sg: SecurityGroup) => {
+          await Promise.all(securityGroups.map(async (sg: SecurityGroup) => {
             if (!sg.vpc) {
               const vpcs: Vpc[] = await AwsVpcModule.mappers.vpc.db.read(ctx);
               if (!vpcs.length) {
@@ -153,7 +153,7 @@ export const AwsSecurityGroupModule: Module = new Module({
               }
             }
             return sg;
-          });
+          }));
           return securityGroups;
         },
         update: async (e: SecurityGroup[], ctx: Context) => {

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -150,10 +150,10 @@ export class Crud<E> {
           // If object is empty it means it is a placeholder and it is not in the memo yet.
           if (!Object.keys(ctx.memo[dest][entityName][id]).length) {
             logger.info(`Cache miss for ${this.entity?.name ?? ''} ${this.dest}`);
-            return undefined;
+          } else {
+            logger.info(`Cache hit for ${this.entity?.name ?? ''} ${this.dest}`);
+            return ctx.memo[dest][entityName][id];
           }
-          logger.info(`Cache hit for ${this.entity?.name ?? ''} ${this.dest}`);
-          return ctx.memo[dest][entityName][id];
         }
         // Linter thinks this is shadowing the other one on line 152 because JS hoisting nonsense
         let o;


### PR DESCRIPTION
Resolves #715 

It was failing because the interface was returning `undefined` the first time while a parallel job was actually reading from cloud. The security group was not mapped correctly and the the security group rule had no security group assigned.