### PR TITLE
Don't 'Promise' more than you can handle

### DIFF
--- a/src/modules/0.0.3/aws_cloudwatch/index.ts
+++ b/src/modules/0.0.3/aws_cloudwatch/index.ts
@@ -6,7 +6,7 @@ import * as metadata from './module.json'
 export const AwsCloudwatchModule: Module = new Module({
   ...metadata,
   utils: {
-    logGroupMapper: (lg: any, _ctx: Context) => {
+    logGroupMapper: (lg: any) => {
       const out = new LogGroup();
       if (!lg?.logGroupName) throw new Error('No log group name defined');
       out.logGroupName = lg.logGroupName;
@@ -25,7 +25,8 @@ export const AwsCloudwatchModule: Module = new Module({
       cloud: new Crud({
         create: async (lg: LogGroup[], ctx: Context) => {
           const client = await ctx.getAwsClient() as AWS;
-          return await Promise.all(lg.map(async (e) => {
+          const out = []
+          for (const e of lg) {
             await client.createLogGroup(e.logGroupName);
             // Re-get the inserted record to get all of the relevant records we care about
             const logGroups = await client.getLogGroups(e.logGroupName);
@@ -34,8 +35,9 @@ export const AwsCloudwatchModule: Module = new Module({
             const newEntity = await AwsCloudwatchModule.utils.logGroupMapper(newObject, ctx);
             // Save the record back into the database to get the new fields updated
             await AwsCloudwatchModule.mappers.logGroup.db.update(newEntity, ctx);
-            return newEntity;
-          }));
+            out.push(newEntity);
+          }
+          return out;
         },
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
@@ -47,21 +49,25 @@ export const AwsCloudwatchModule: Module = new Module({
           } else {
             logGroups = (await client.getLogGroups()) ?? [];
           }
-          return await Promise.all(logGroups.map((lg: any) => AwsCloudwatchModule.utils.logGroupMapper(lg, ctx)));
+          return logGroups.map((lg: any) => AwsCloudwatchModule.utils.logGroupMapper(lg));
         },
         updateOrReplace: () => 'update',
         update: async (es: LogGroup[], ctx: Context) => {
           // Right now we can only modify AWS-generated fields in the database.
           // This implies that on `update`s we only have to restore the values for those records.
-          return await Promise.all(es.map(async (e) => {
+          const out = [];
+          for (const e of es) {
             const cloudRecord = ctx?.memo?.cloud?.LogGroup?.[e.logGroupName ?? ''];
             await AwsCloudwatchModule.mappers.logGroup.db.update(cloudRecord, ctx);
-            return cloudRecord;
-          }));
+            out.push(cloudRecord);
+          }
+          return out;
         },
         delete: async (lg: LogGroup[], ctx: Context) => {
           const client = await ctx.getAwsClient() as AWS;
-          await Promise.all(lg.map((e) => client.deleteLogGroup(e.logGroupName)));
+          for (const e of lg) {
+            await client.deleteLogGroup(e.logGroupName);
+          }
         },
       }),
     }),

--- a/src/modules/0.0.3/aws_ec2/index.ts
+++ b/src/modules/0.0.3/aws_ec2/index.ts
@@ -58,11 +58,11 @@ export const AwsEc2Module: Module = new Module({
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
           const instances = Array.isArray(ids) ? await (async () => {
-            const out = [];
+            const o = [];
             for (const id of ids) {
-              out.push(await client.getInstance(id));
+              o.push(await client.getInstance(id));
             }
-            return out;
+            return o;
           })() :
             (await client.getInstances()).Instances ?? [];
           // ignore instances in "Terminated" and "Shutting down" state

--- a/src/modules/0.0.3/aws_elb/index.ts
+++ b/src/modules/0.0.3/aws_elb/index.ts
@@ -144,11 +144,11 @@ export const AwsElbModule: Module = new Module({
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
           const listeners = Array.isArray(ids) ? await (async () => {
-            const out = [];
+            const o = [];
             for (const id of ids) {
-              out.push(await client.getListener(id));
+              o.push(await client.getListener(id));
             }
-            return out;
+            return o;
           })() :
             await (async () => {
               // TODO: Should this behavior be standard?
@@ -261,11 +261,11 @@ export const AwsElbModule: Module = new Module({
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
           const lbs = Array.isArray(ids) ? await (async () => {
-            const out = [];
+            const o = [];
             for (const id of ids) {
-              out.push(await client.getLoadBalancer(id));
+              o.push(await client.getLoadBalancer(id));
             }
-            return out;
+            return o;
           })() :
             (await client.getLoadBalancers()).LoadBalancers;
           const out = [];
@@ -397,11 +397,11 @@ export const AwsElbModule: Module = new Module({
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
           const tgs = Array.isArray(ids) ? await (async () => {
-            const out = [];
+            const o = [];
             for (const id of ids) {
-              out.push(await client.getTargetGroup(id));
+              o.push(await client.getTargetGroup(id));
             }
-            return out;
+            return o;
           })() :
             (await client.getTargetGroups()).TargetGroups;
           const out = [];

--- a/src/modules/0.0.3/aws_iam/index.ts
+++ b/src/modules/0.0.3/aws_iam/index.ts
@@ -14,7 +14,7 @@ export const AwsIamModule: Module = new Module({
       out.roleName = role.RoleName ?? '';
       out.description = role.Description ?? '';
       out.assumeRolePolicyDocument = decodeURIComponent(role.AssumeRolePolicyDocument ?? '');
-      return out
+      return out;
     },
     roleNameFromArn: (arn: string, _ctx: Context) => {
       const roleName = arn.split(':role/')[1];
@@ -58,11 +58,11 @@ export const AwsIamModule: Module = new Module({
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
           const roles = Array.isArray(ids) ? await (async () => {
-            const out = [];
+            const o = [];
             for (const id of ids) {
-              out.push(await client.getRole(id));
+              o.push(await client.getRole(id));
             }
-            return out;
+            return o;
           })() :
             (await client.getRoles()) ?? [];
           const out = [];

--- a/src/modules/0.0.3/aws_iam/index.ts
+++ b/src/modules/0.0.3/aws_iam/index.ts
@@ -8,7 +8,7 @@ import * as metadata from './module.json'
 export const AwsIamModule: Module = new Module({
   ...metadata,
   utils: {
-    roleMapper: (role: AWSRole, _ctx: Context) => {
+    roleMapper: (role: AWSRole) => {
       const out = new Role();
       out.arn = role.Arn;
       out.roleName = role.RoleName ?? '';
@@ -38,8 +38,9 @@ export const AwsIamModule: Module = new Module({
       cloud: new Crud({
         create: async (es: Role[], ctx: Context) => {
           const client = await ctx.getAwsClient() as AWS;
-          return await Promise.all(es.map(async (role) => {
-            const roleArn = await client.newRole(
+          const out = [];
+          for (const role of es) {
+            const roleArn = await client.newRoleLin(
               role.roleName,
               role.assumeRolePolicyDocument,
               role.attachedPoliciesArns,
@@ -50,31 +51,39 @@ export const AwsIamModule: Module = new Module({
             }
             role.arn = roleArn;
             await AwsIamModule.mappers.role.db.update(role, ctx);
-            return role;
-          }));
+            out.push(role);
+          }
+          return out;
         },
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
-          const roles = Array.isArray(ids) ?
-            await Promise.all(ids.map(id => client.getRole(id))) :
+          const roles = Array.isArray(ids) ? await (async () => {
+            const out = [];
+            for (const id of ids) {
+              out.push(await client.getRole(id));
+            }
+            return out;
+          })() :
             (await client.getRoles()) ?? [];
-          return await Promise.all(roles
-            .map(async (r) => {
-              const role = AwsIamModule.utils.roleMapper(r, ctx);
-              role.attachedPoliciesArns = await client.getRoleAttachedPoliciesArns(role.roleName);
-              return role;
-            })
-          );
+          const out = [];
+          for (const r of roles) {
+            const role = AwsIamModule.utils.roleMapper(r);
+            role.attachedPoliciesArns = await client.getRoleAttachedPoliciesArns(role.roleName);
+            out.push(role);
+          }
+          return out;
         },
         updateOrReplace: () => 'update',
         update: async (es: Role[], ctx: Context) => {
           const client = await ctx.getAwsClient() as AWS;
-          return await Promise.all(es.map(async (e) => {
+          const out = [];
+          for (const e of es) {
             const cloudRecord = ctx?.memo?.cloud?.Role?.[e.roleName ?? ''];
             // aws-service-roles are immutable so undo change and return
             if (cloudRecord.arn.includes(':role/aws-service-role/')) {
               await AwsIamModule.mappers.role.db.update(cloudRecord, ctx);
-              return cloudRecord
+              out.push(cloudRecord);
+              continue;
             }
             const b = cloudRecord;
             let update = false;
@@ -93,8 +102,9 @@ export const AwsIamModule: Module = new Module({
               updatedRecord.attachedPoliciesArns = await client.getRoleAttachedPoliciesArns(updatedRecord.roleName);
             }
             await AwsIamModule.mappers.role.db.update(updatedRecord, ctx);
-            return updatedRecord;
-          }));
+            out.push(updatedRecord);
+          }
+          return out;
         },
         delete: async (es: Role[], ctx: Context) => {
           const client = await ctx.getAwsClient() as AWS;
@@ -104,7 +114,7 @@ export const AwsIamModule: Module = new Module({
               if (entity.arn.includes(':role/aws-service-role/')) {
                 await AwsIamModule.mappers.role.db.create(entity, ctx);
               } else {
-                await client.deleteRole(entity.roleName, entity.attachedPoliciesArns);
+                await client.deleteRoleLin(entity.roleName, entity.attachedPoliciesArns);
               }
             }
           }

--- a/src/modules/0.0.3/aws_rds/index.ts
+++ b/src/modules/0.0.3/aws_rds/index.ts
@@ -92,11 +92,11 @@ export const AwsRdsModule: Module = new Module({
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
           const rdses = Array.isArray(ids) ? await (async () => {
-            const out = [];
+            const o = [];
             for (const id of ids) {
-              out.push(await client.getDBInstance(id));
+              o.push(await client.getDBInstance(id));
             }
-            return out;
+            return o;
           })() :
             (await client.getDBInstances()).DBInstances;
           const out = [];

--- a/src/modules/0.0.3/aws_rds/index.ts
+++ b/src/modules/0.0.3/aws_rds/index.ts
@@ -49,7 +49,8 @@ export const AwsRdsModule: Module = new Module({
       cloud: new Crud({
         create: async (es: RDS[], ctx: Context) => {
           const client = await ctx.getAwsClient() as AWS;
-          return await Promise.all(es.map(async (e) => {
+          const out = [];
+          for (const e of es) {
             const securityGroupIds = e.vpcSecurityGroups?.map(sg => {
               if (!sg.groupId) throw new Error('Security group needs to exist')
               return sg.groupId;
@@ -84,20 +85,31 @@ export const AwsRdsModule: Module = new Module({
             newEntity.masterUserPassword = null;
             // Save the record back into the database to get the new fields updated
             await AwsRdsModule.mappers.rds.db.update(newEntity, ctx);
-            return newEntity;
-          }));
+            out.push(newEntity);
+          }
+          return out;
         },
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
-          const rdses = Array.isArray(ids) ?
-            await Promise.all(ids.map(id => client.getDBInstance(id))) :
+          const rdses = Array.isArray(ids) ? await (async () => {
+            const out = [];
+            for (const id of ids) {
+              out.push(await client.getDBInstance(id));
+            }
+            return out;
+          })() :
             (await client.getDBInstances()).DBInstances;
-          return await Promise.all(rdses.map(rds => AwsRdsModule.utils.rdsMapper(rds, ctx)));
+          const out = [];
+          for (const rds of rdses) {
+            out.push(await AwsRdsModule.utils.rdsMapper(rds, ctx));
+          }
+          return out;
         },
         updateOrReplace: () => 'update',
         update: async (es: RDS[], ctx: Context) => {
           const client = await ctx.getAwsClient() as AWS;
-          return await Promise.all(es.map(async (e) => {
+          const out = [];
+          for (const e of es) {
             const cloudRecord = ctx?.memo?.cloud?.RDS?.[e.dbInstanceIdentifier ?? ''];
             let updatedRecord = { ...cloudRecord };
             if (!(Object.is(e.dbInstanceClass, cloudRecord.dbInstanceClass)
@@ -132,12 +144,13 @@ export const AwsRdsModule: Module = new Module({
             // Reminder: Password need to be null since when we read RDS instances from AWS this property is not retrieved
             updatedRecord.masterUserPassword = null;
             await AwsRdsModule.mappers.rds.db.update(updatedRecord, ctx);
-            return updatedRecord;
-          }));
+            out.push(updatedRecord);
+          }
+          return out;
         },
         delete: async (es: RDS[], ctx: Context) => {
           const client = await ctx.getAwsClient() as AWS;
-          await Promise.all(es.map(async (e) => {
+          for (const e of es) {
             const input = {
               DBInstanceIdentifier: e.dbInstanceIdentifier,
               // TODO: do users will have access to this type of config?
@@ -148,7 +161,7 @@ export const AwsRdsModule: Module = new Module({
               // DeleteAutomatedBackups: false,
             };
             return client.deleteDBInstance(input);
-          }));
+          }
         },
       }),
     }),

--- a/src/modules/0.0.3/aws_route53_hosted_zones/index.ts
+++ b/src/modules/0.0.3/aws_route53_hosted_zones/index.ts
@@ -93,7 +93,7 @@ export const AwsRoute53HostedZoneModule: Module = new Module({
           const client = await ctx.getAwsClient() as AWS;
           for (const e of hz) {
             await client.deleteHostedZone(e.hostedZoneId);
-          } 
+          }
         },
       }),
     }),

--- a/src/modules/0.0.3/aws_route53_hosted_zones/index.ts
+++ b/src/modules/0.0.3/aws_route53_hosted_zones/index.ts
@@ -154,7 +154,7 @@ export const AwsRoute53HostedZoneModule: Module = new Module({
           const out = [];
           for (const r of records) {
             const rec = await AwsRoute53HostedZoneModule.utils.resourceRecordSetMapper(r, ctx);
-            if (!rec) out.push(rec);
+            if (rec) out.push(rec);
           }
           return out;
         },

--- a/src/modules/0.0.3/aws_security_group/index.ts
+++ b/src/modules/0.0.3/aws_security_group/index.ts
@@ -211,6 +211,7 @@ export const AwsSecurityGroupModule: Module = new Module({
               const cloudRecord = ctx?.memo?.cloud?.SecurityGroup?.[e.groupId ?? ''];
               cloudRecord.id = e.id;
               await AwsSecurityGroupModule.mappers.securityGroup.db.update(cloudRecord, ctx);
+              ctx.memo.db.SecurityGroup[cloudRecord.groupId] = cloudRecord; // Force the cache
             } else {
               // AWS does not have a way to update the top-level SecurityGroup entity. You can
               // update the various rules associated with it, but not the name or description of the

--- a/src/modules/0.0.3/aws_security_group/index.ts
+++ b/src/modules/0.0.3/aws_security_group/index.ts
@@ -183,11 +183,11 @@ export const AwsSecurityGroupModule: Module = new Module({
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
           const sgs = Array.isArray(ids) ? await (async () => {
-            const out = [];
+            const o = [];
             for (const id of ids) {
-              out.push(await client.getSecurityGroup(id));
+              o.push(await client.getSecurityGroup(id));
             }
-            return out;
+            return o;
           })() :
             (await client.getSecurityGroups()).SecurityGroups;
           const out = [];
@@ -372,11 +372,11 @@ export const AwsSecurityGroupModule: Module = new Module({
         read: async (ctx: Context, ids?: string[]) => {
           const client = await ctx.getAwsClient() as AWS;
           const sgrs = Array.isArray(ids) ? await (async () => {
-            const out = [];
+            const o = [];
             for (const id of ids) {
-              out.push(await client.getSecurityGroupRule(id));
+              o.push(await client.getSecurityGroupRule(id));
             }
-            return out;
+            return o;
           })() :
             (await client.getSecurityGroupRules()).SecurityGroupRules;
           const out = [];

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -457,7 +457,7 @@ export async function apply(dbId: string, dryRun: boolean, ormOpt?: TypeormWrapp
               }));
             }
             if (r.diff.entitiesChanged.length > 0) {
-              logger.info(`${name} has records to update`);
+              logger.info(`${name} has records to update`, { records: r.diff.entitiesChanged, });
               outArr.push(r.diff.entitiesChanged.map((ec: any) => async () => {
                 const out = await r.mapper.cloud.update(ec.db, context); // Assuming SoT is the DB
                 if (out) {
@@ -664,7 +664,7 @@ export async function sync(dbId: string, dryRun: boolean, ormOpt?: TypeormWrappe
               }));
             }
             if (r.diff.entitiesChanged.length > 0) {
-              logger.info(`${name} has records to update`);
+              logger.info(`${name} has records to update`, { records: r.diff.entitiesChanged, });
               outArr.push(r.diff.entitiesChanged.map((ec: any) => async () => {
                 ec.cloud.id = ec.db.id;
                 const out = await r.mapper.db.update(ec.cloud, context); // When `sync`ing we assume SoT is the Cloud

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -855,6 +855,7 @@ ${Object.keys(tableCollisions)
       }
       const e = new Modules.IasqlPlatform.utils.IasqlModule();
       e.name = `${md.name}@${md.version}`;
+      // Promise.all is okay here because it's guaranteed to not hit the cloud services
       e.dependencies = await Promise.all(
         md.dependencies.map(async (dep) => await orm.findOne(Modules.IasqlPlatform.utils.IasqlModule, { name: dep, }))
       );


### PR DESCRIPTION
Despite some issues in reproducing some error conditions we've seen recently, most of them were caused by hitting the AWS API rate limiter, and that should only be possible by making API requests in parallel.

`Promise.all` requires an array of promises to `await` on, but for those promises to all be created they must have been kicked off, and therefore they're operating in parallel with each other. On top of that, this parallelization can cause double-requests (or more) for resources that aren't in our cache yet since the check for the resource happened before any of the requests responded. By switching to `for-await` loops instead, we linearize the code more, which should prevent the rate limiting errors (I hope) but also reduce wasteful duplicate queries by increasing the cache hit success rate.