### PR TITLE
Only use the logger (except when absolutely necessary to avoid)

### DIFF
--- a/src/scripts/list-deps.ts
+++ b/src/scripts/list-deps.ts
@@ -1,3 +1,4 @@
+/* tslint:disable no-console */
 import { getModJsons, ModJson, } from './module-json-utils'
 
 const moduleName = process.argv[process.argv.length - 2];

--- a/src/scripts/migrate-dep-order.ts
+++ b/src/scripts/migrate-dep-order.ts
@@ -1,3 +1,4 @@
+/* tslint:disable no-console */
 import { sortMods, getModMigration, } from './module-json-utils'
 import { TypeormWrapper, } from '../services/typeorm'
 

--- a/src/scripts/module-json-utils.ts
+++ b/src/scripts/module-json-utils.ts
@@ -1,3 +1,4 @@
+/* tslint:disable no-console */
 import fs from 'fs'
 
 export type ModJson = {

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,3 +1,4 @@
+/* tslint:disable no-console */
 import * as util from 'util'
 
 import * as sentry from '@sentry/node'

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -18,8 +18,7 @@ export async function execComposeDown(modules?: string[], region?: string) {
     try {
       await cleanDB(modules, region);
     } catch (e: any) {
-      console.log(`Error cleaning db with error: ${e.message}`);
-      console.dir(e, {depth: 6});
+      logger.error(`Error cleaning db with error: ${e.message}`, e);
     }
   }
   execSync('cd test && docker-compose down');

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,6 @@
   "rules": {
     "one-variable-per-declaration": false,
     "ban-types": false,
-    "no-console": false,
     "max-classes-per-file": 9001
   },
   "rulesDirectory": [],


### PR DESCRIPTION
Minor cleanup PR. Disables usage of `console.log` and friends except in the scripts directory (because weird circular dep issues when using code that creates code) and within our logger definition itself.