### PR TITLE
Add an audit log

### DIFF
--- a/src/modules/0.0.4/iasql_functions/sql/create_fns.sql
+++ b/src/modules/0.0.4/iasql_functions/sql/create_fns.sql
@@ -1,17 +1,18 @@
 -- TODO: Does this belong here or in a similar file in the iasql_platform module?
-create or replace function iasql_audit() returns trigger as $$
+create or replace function iasql_audit() returns trigger
 language plpgsql security definer
+as $$
 begin
   if (TG_OP = 'INSERT') then
     INSERT INTO iasql_audit_log (ts, "user", table_name, change_type, change)
-    VALUES (now(), user, TG_TABLE_NAME, 'INSERT', '{"change":' || to_json(NEW.*) || '}');
-  elif (TG_OP = 'DELETE') then
+    VALUES (now(), user, TG_TABLE_NAME, 'INSERT', ('{"change":' || to_json(NEW.*) || '}')::json);
+  elsif (TG_OP = 'DELETE') then
     INSERT INTO iasql_audit_log (ts, "user", table_name, change_type, change)
-    VALUES (now(), user, TG_TABLE_NAME, 'DELETE', '{"original":' || to_json(OLD.*) || '}');
-  elif (TG_OP = 'UPDATE') then
+    VALUES (now(), user, TG_TABLE_NAME, 'DELETE', ('{"original":' || to_json(OLD.*) || '}')::json);
+  elsif (TG_OP = 'UPDATE') then
     INSERT INTO iasql_audit_log (ts, "user", table_name, change_type, change)
-    VALUES (now(), user, TG_TABLE_NAME, 'UPDATE', '{"original":' || to_json(OLD.*) || ', "change":' || to_json(NEW.*) || '}');
-  endif;
+    VALUES (now(), user, TG_TABLE_NAME, 'UPDATE', ('{"original":' || to_json(OLD.*) || ', "change":' || to_json(NEW.*) || '}')::json);
+  end if;
   return NULL;
 end;
 $$;

--- a/src/modules/0.0.4/iasql_functions/sql/drop_fns.sql
+++ b/src/modules/0.0.4/iasql_functions/sql/drop_fns.sql
@@ -13,3 +13,4 @@ DROP FUNCTION "iasql_apply";
 DROP FUNCTION "iasql_plan_apply";
 DROP FUNCTION "iasql_cloud_manipulation";
 DROP FUNCTION "until_iasql_operation";
+DROP FUNCTION "iasql_audit";

--- a/src/modules/0.0.4/iasql_platform/entity/index.ts
+++ b/src/modules/0.0.4/iasql_platform/entity/index.ts
@@ -6,6 +6,7 @@ import {
   ManyToMany,
   ManyToOne,
   OneToMany,
+  PrimaryGeneratedColumn,
 } from 'typeorm'
 
 @Entity()
@@ -45,4 +46,42 @@ export class IasqlTables {
 
   @Column({ nullable: false, primary: true, })
   table: string;
+}
+
+export enum AuditLogChangeType {
+  INSERT = 'INSERT',
+  UPDATE = 'UPDATE',
+  DELETE = 'DELETE',
+}
+
+@Entity()
+export class IasqlAuditLog {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({
+    type: 'timestamp without time zone',
+  })
+  ts: Date;
+
+  @Column()
+  user: string;
+
+  @Column()
+  tableName: string;
+
+  @Column({
+    type: 'enum',
+    enum: AuditLogChangeType,
+  })
+  changeType: AuditLogChangeType;
+
+  // The actual change will be encoded into a JSON with two optional top-level properties, named
+  // `original` and `change`. An UPDATE will have both properties specified, an INSERT will only
+  // contain `change`, and a DELETE will only contain `original`. I do not know how to enforce this
+  // any better than by comment. :_)
+  @Column({
+    type: 'json',
+  })
+  change: { original?: any, change?: any, };
 }

--- a/src/modules/0.0.4/iasql_platform/migration/1652392022919-iasql_platform.ts
+++ b/src/modules/0.0.4/iasql_platform/migration/1652392022919-iasql_platform.ts
@@ -1,11 +1,13 @@
 import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class iasqlPlatform1649298097680 implements MigrationInterface {
-    name = 'iasqlPlatform1649298097680'
+export class iasqlPlatform1652392022919 implements MigrationInterface {
+    name = 'iasqlPlatform1652392022919'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TABLE "iasql_module" ("name" character varying NOT NULL, CONSTRAINT "UQ_e91a0b0e9a029428405fdd17ee4" UNIQUE ("name"), CONSTRAINT "PK_e91a0b0e9a029428405fdd17ee4" PRIMARY KEY ("name"))`);
         await queryRunner.query(`CREATE TABLE "iasql_tables" ("table" character varying NOT NULL, "module" character varying NOT NULL, CONSTRAINT "PK_2e2832f9cf90115571eb803a943" PRIMARY KEY ("table", "module"))`);
+        await queryRunner.query(`CREATE TYPE "public"."iasql_audit_log_change_type_enum" AS ENUM('INSERT', 'UPDATE', 'DELETE')`);
+        await queryRunner.query(`CREATE TABLE "iasql_audit_log" ("id" SERIAL NOT NULL, "ts" TIMESTAMP NOT NULL, "user" character varying NOT NULL, "table_name" character varying NOT NULL, "change_type" "public"."iasql_audit_log_change_type_enum" NOT NULL, "change" json NOT NULL, CONSTRAINT "PK_96a7317761701ced55a158c195d" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TABLE "iasql_dependencies" ("module" character varying NOT NULL, "dependency" character varying NOT NULL, CONSTRAINT "PK_b07797cfc364fa84b6da165f89d" PRIMARY KEY ("module", "dependency"))`);
         await queryRunner.query(`CREATE INDEX "IDX_9732df6d7dff34b6f6a1732033" ON "iasql_dependencies" ("module") `);
         await queryRunner.query(`CREATE INDEX "IDX_7dbdaef2c45fdd0d1d82cc9568" ON "iasql_dependencies" ("dependency") `);
@@ -21,6 +23,8 @@ export class iasqlPlatform1649298097680 implements MigrationInterface {
         await queryRunner.query(`DROP INDEX "public"."IDX_7dbdaef2c45fdd0d1d82cc9568"`);
         await queryRunner.query(`DROP INDEX "public"."IDX_9732df6d7dff34b6f6a1732033"`);
         await queryRunner.query(`DROP TABLE "iasql_dependencies"`);
+        await queryRunner.query(`DROP TABLE "iasql_audit_log"`);
+        await queryRunner.query(`DROP TYPE "public"."iasql_audit_log_change_type_enum"`);
         await queryRunner.query(`DROP TABLE "iasql_tables"`);
         await queryRunner.query(`DROP TABLE "iasql_module"`);
     }

--- a/src/scripts/migrate-dep-order.ts
+++ b/src/scripts/migrate-dep-order.ts
@@ -1,6 +1,8 @@
 /* tslint:disable no-console */
+import { createConnection, } from 'typeorm'
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+
 import { sortMods, getModMigration, } from './module-json-utils'
-import { TypeormWrapper, } from '../services/typeorm'
 
 const moduleName = process.argv[process.argv.length - 2];
 const moduleVersion = process.argv[process.argv.length - 1];
@@ -15,11 +17,15 @@ if (moduleName !== 'iasql_platform') {
 const entities = sortedDeps.map(d => `${__dirname}/../modules/${moduleVersion}/${d.name}/entity/*.ts`) as any[]
 
 (async () => {
-  const conn = await TypeormWrapper.createConn('__example__', {
-    entities,
+  const conn = await createConnection({
+    type: 'postgres',
+    name: '__example__',
+    database: '__example__',
     host: 'localhost',
     username: 'postgres',
     password: 'test',
+    namingStrategy: new SnakeNamingStrategy(),
+    entities,
   });
 
   const qr = conn.createQueryRunner();

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -870,6 +870,16 @@ ${Object.keys(tableCollisions)
         return mt;
       }) ?? [];
       await orm.save(Modules.IasqlPlatform.utils.IasqlTables, modTables);
+      // For each table, we need to attach the audit log trigger, if the platform is >=0.0.4
+      if (!['v0_0_1', 'v0_0_2', 'v0_0_3'].includes(versionString)) {
+        for (const table of md.provides.tables) {
+          await queryRunner.query(`
+            CREATE TRIGGER ${table}_audit
+            AFTER INSERT OR UPDATE OR DELETE ON ${table}
+            FOR EACH ROW EXECUTE FUNCTION iasql_audit();
+          `);
+        }
+      }
     }
     await queryRunner.commitTransaction();
     await orm.query(dbMan.grantPostgresRoleQuery(dbUser));
@@ -964,6 +974,14 @@ export async function uninstall(moduleList: string[], dbId: string, orm?: Typeor
   await queryRunner.startTransaction();
   try {
     for (const md of leafToRootOrder) {
+      // For each table, we need to attach the audit log trigger, if the platform is >=0.0.4
+      if (!['v0_0_1', 'v0_0_2', 'v0_0_3'].includes(versionString)) {
+        for (const table of md.provides.tables) {
+          await queryRunner.query(`
+            DROP TRIGGER IF EXISTS ${table}_audit ON ${table};
+          `);
+        }
+      }
       if (md.migrations?.remove) {
         await md.migrations.remove(queryRunner);
       }


### PR DESCRIPTION
- Add the new 'iasql_audit_log' table to the platform and fix the module migration generation to require zero config changes to run
- Write the audit trigger function and attach/detach it on install/uninstall
- Syntax fixes for the trigger function
