### PR TITLE
Move the graphile workers into a child process

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import cors from 'cors';
 import express from 'express';
 import { inspect } from 'util';
 
-import * as scheduler from './services/scheduler'
+import * as scheduler from './services/scheduler-api'
 import MetadataRepo from './services/repositories/metadata';
 import config from './config';
 import logger from './services/logger'

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -12,7 +12,7 @@ import { snakeCase, } from 'typeorm/util/StringUtils'
 
 import * as AllModules from '../modules'
 import * as dbMan from './db-manager'
-import * as scheduler from './scheduler'
+import * as scheduler from './scheduler-api'
 import MetadataRepo from './repositories/metadata'
 import config from '../config'
 import logger, { debugObj } from './logger'

--- a/src/services/repositories/metadata.ts
+++ b/src/services/repositories/metadata.ts
@@ -11,6 +11,8 @@ class MetadataRepo {
   private userRepo: Repository<IasqlUser>;
   private dbRepo: Repository<IasqlDatabase>;
 
+  initialized: boolean;
+
   async init() {
     const conn = await createConnection(dbMan.baseConnConfig);
     try {
@@ -33,6 +35,7 @@ class MetadataRepo {
     await this.conn.runMigrations();
     this.userRepo = this.conn.getRepository(IasqlUser);
     this.dbRepo = this.conn.getRepository(IasqlDatabase);
+    this.initialized = true;
   }
 
   async saveDb(a0Id: string, email: string, db: IasqlDatabase): Promise<IasqlDatabase> {

--- a/src/services/scheduler-api.ts
+++ b/src/services/scheduler-api.ts
@@ -1,0 +1,43 @@
+import childProcess from 'child_process'
+import { readdirSync } from 'fs'
+
+import { v4 as uuidv4, } from 'uuid'
+
+import * as scheduler from './scheduler'
+import logger from './logger'
+
+// We have to test the current directory if it's Typescript or Javascript. When running in `ts-node`
+// mode I do not expect childProcess to actually work, but also in that situation we don't need to
+// put the workers into a separate process for Kubernetes' sake since that's only during testing,
+// so in that case, we can just pass-through re-export the graphile worker scheduler.
+const files = readdirSync('./');
+const isTs = files.some(file => /.ts$/.test(file));
+
+const child = isTs ? undefined : childProcess.fork(`${__dirname}/scheduler.js`);
+
+// Primitive RPC handler. Only the parent process can trigger an RPC call, so we can track it all
+// here. Currently-active requests are turned into promises that are eventually resolved by the
+// child process' return message, identified by a unique ID each message includes at the end
+const messagePromises: { [key: string]: any, } = {};
+
+function simpleRpc(fn: string, ...args: string[]) {
+  const id = uuidv4();
+  const p = new Promise((resolve) => {
+    messagePromises[id] = resolve;
+  });
+  child?.send?.([fn, ...args, id]);
+  return p;
+}
+
+if (!isTs) child?.on('message', (m: string[]) => {
+  // By convention, the last returned value is the id. Other values are passed back for debugging
+  // purposes
+  logger.debug('Scheduler child process message', { m, });
+  const id = m.pop() as string;
+  messagePromises[id]?.();
+});
+
+export const init = isTs ? scheduler.init : simpleRpc.bind(this, 'init');
+export const start = isTs ? scheduler.start : simpleRpc.bind(this, 'start');
+export const stop = isTs ? scheduler.stop : simpleRpc.bind(this, 'stop');
+export const stopAll = isTs ? scheduler.stop : simpleRpc.bind(this, 'stopAll');

--- a/src/services/scheduler-api.ts
+++ b/src/services/scheduler-api.ts
@@ -18,12 +18,12 @@ const child = isTs ? undefined : childProcess.fork(`${__dirname}/scheduler.js`);
 // Primitive RPC handler. Only the parent process can trigger an RPC call, so we can track it all
 // here. Currently-active requests are turned into promises that are eventually resolved by the
 // child process' return message, identified by a unique ID each message includes at the end
-const messagePromises: { [key: string]: any, } = {};
+const messagePromises: { [key: string]: any[], } = {};
 
 function simpleRpc(fn: string, ...args: string[]) {
   const id = uuidv4();
-  const p = new Promise((resolve) => {
-    messagePromises[id] = resolve;
+  const p = new Promise((resolve, reject) => {
+    messagePromises[id] = [resolve, reject];
   });
   child?.send?.([fn, ...args, id]);
   return p;
@@ -33,8 +33,9 @@ if (!isTs) child?.on('message', (m: string[]) => {
   // By convention, the last returned value is the id. Other values are passed back for debugging
   // purposes
   logger.debug('Scheduler child process message', { m, });
+  const error = m.pop();
   const id = m.pop() as string;
-  messagePromises[id]?.();
+  messagePromises[id][!!error ? 1 : 0]?.(!!error ? new Error(error) : undefined);
 });
 
 export const init = () => isTs ? scheduler.init() : simpleRpc('init');

--- a/src/services/scheduler-api.ts
+++ b/src/services/scheduler-api.ts
@@ -1,5 +1,5 @@
 import childProcess from 'child_process'
-import { readdirSync } from 'fs'
+import { readdirSync, } from 'fs'
 
 import { v4 as uuidv4, } from 'uuid'
 
@@ -37,7 +37,7 @@ if (!isTs) child?.on('message', (m: string[]) => {
   messagePromises[id]?.();
 });
 
-export const init = isTs ? scheduler.init : simpleRpc.bind(this, 'init');
-export const start = isTs ? scheduler.start : simpleRpc.bind(this, 'start');
-export const stop = isTs ? scheduler.stop : simpleRpc.bind(this, 'stop');
-export const stopAll = isTs ? scheduler.stopAll : simpleRpc.bind(this, 'stopAll');
+export const init = () => isTs ? scheduler.init() : simpleRpc('init');
+export const start = (dbId: string, dbUser: string) => isTs ? scheduler.start(dbId, dbUser) : simpleRpc('start', dbId, dbUser);
+export const stop = (dbId: string) => isTs ? scheduler.stop(dbId) : simpleRpc('stop', dbId);
+export const stopAll = () => isTs ? scheduler.stopAll() : simpleRpc('stopAll');

--- a/src/services/scheduler-api.ts
+++ b/src/services/scheduler-api.ts
@@ -10,8 +10,8 @@ import logger from './logger'
 // mode I do not expect childProcess to actually work, but also in that situation we don't need to
 // put the workers into a separate process for Kubernetes' sake since that's only during testing,
 // so in that case, we can just pass-through re-export the graphile worker scheduler.
-const files = readdirSync('./');
-const isTs = files.some(file => /.ts$/.test(file));
+const files = readdirSync(__dirname);
+const isTs = files.some(file => /.*ts$/.test(file));
 
 const child = isTs ? undefined : childProcess.fork(`${__dirname}/scheduler.js`);
 

--- a/src/services/scheduler-api.ts
+++ b/src/services/scheduler-api.ts
@@ -40,4 +40,4 @@ if (!isTs) child?.on('message', (m: string[]) => {
 export const init = isTs ? scheduler.init : simpleRpc.bind(this, 'init');
 export const start = isTs ? scheduler.start : simpleRpc.bind(this, 'start');
 export const stop = isTs ? scheduler.stop : simpleRpc.bind(this, 'stop');
-export const stopAll = isTs ? scheduler.stop : simpleRpc.bind(this, 'stopAll');
+export const stopAll = isTs ? scheduler.stopAll : simpleRpc.bind(this, 'stopAll');

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -148,6 +148,7 @@ export async function stopAll() {
 
 // spin up a worker for every db that this server is already managing
 export async function init() {
+  if (!MetadataRepo.initialized) await MetadataRepo.init(); // Necessary in the child process
   const dbs: IasqlDatabase[] = await MetadataRepo.getAllDbs();
   const inits = await Promise.allSettled(dbs.map(db => start(db.pgName, db.pgUser)));
   for (const bootstrap of inits) {

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -164,16 +164,24 @@ process.on('message', (m: string[]) => {
   const [fn, ...args] = m;
   switch (fn) {
     case 'init':
-      init().then(() => process.send?.(['initComplete', ...args]));
+      init()
+        .then(() => process.send?.(['initComplete', ...args, undefined]))
+        .catch((e) => process.send?.(['initComplete', ...args, e.message]));
       break;
     case 'start':
-      start(args[0], args[1]).then(() => process.send?.(['startComplete', ...args]));
+      start(args[0], args[1])
+        .then(() => process.send?.(['startComplete', ...args, undefined]))
+        .catch((e) => process.send?.(['startComplete', ...args, e.message]));
       break;
     case 'stop':
-      stop(args[0]).then(() => process.send?.(['stopComplete', ...args]));
+      stop(args[0])
+        .then(() => process.send?.(['stopComplete', ...args, undefined]))
+        .catch((e) => process.send?.(['stopComplete', ...args, e.message]));
       break;
     case 'stopAll':
-      stopAll().then(() => process.send?.(['stopAllComplete', ...args]));
+      stopAll()
+        .then(() => process.send?.(['stopAllComplete', ...args, undefined]))
+        .catch((e) => process.send?.(['stopAllComplete', ...args, e.message]));
       break;
   }
 });

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -156,3 +156,23 @@ export async function init() {
     }
   }
 }
+
+// Primitive RPC between parent and child process. Requires the parent to produce a unique ID per
+// request to pair up to the correct response. May replace with a revived multitransport-jsonrpc?
+process.on('message', (m: string[]) => {
+  const [fn, ...args] = m;
+  switch (fn) {
+    case 'init':
+      init().then(() => process.send?.(['initComplete', ...args]));
+      break;
+    case 'start':
+      start(args[0], args[1]).then(() => process.send?.(['startComplete', ...args]));
+      break;
+    case 'stop':
+      stop(args[0]).then(() => process.send?.(['stopComplete', ...args]));
+      break;
+    case 'stopAll':
+      stopAll().then(() => process.send?.(['stopAllComplete', ...args]));
+      break;
+  }
+});


### PR DESCRIPTION
- Convert the graphile worker scheduler into a child process
- We no longer have a single singleton for the metadata database access
