### PR TITLE
Fix looping when no security group defined on EC2

### DIFF
--- a/test/modules/aws-ec2-integration.ts
+++ b/test/modules/aws-ec2-integration.ts
@@ -165,6 +165,37 @@ describe('EC2 Integration Testing', () => {
     FROM instance;
   `, (res: any[]) => expect(res.length).toBe(2)));
 
+  it('adds an ec2 instance with no security group', (done) => {
+    query(`
+      INSERT INTO instance (ami, instance_type, tags)
+      VALUES ('${amznAmiId}', 't2.micro', '{"name":"${prefix}-nosg"}');
+    `)((e?: any) => {
+      if (!!e) return done(e);
+      done();
+    });
+  });
+
+  it('check number of instances', query(`
+    SELECT *
+    FROM instance
+    WHERE tags ->> 'name' = '${prefix}-nosg';
+  `, (res: any[]) => expect(res.length).toBe(1)));
+
+  it('applies the created instances', apply());
+
+  it('check number of instances', query(`
+    SELECT *
+    FROM instance
+    WHERE tags ->> 'name' = '${prefix}-nosg';
+  `, (res: any[]) => expect(res.length).toBe(1)));
+
+  it('check number of security groups for instance', query(`
+    SELECT *
+    FROM instance_security_groups
+    INNER JOIN instance ON instance.id = instance_security_groups.instance_id
+    WHERE tags ->> 'name' = '${prefix}-nosg';
+  `, (res: any[]) => expect(res.length).toBe(1)));
+
   it('deletes both ec2 instances', query(`
     DELETE FROM instance;
   `));

--- a/test/modules/aws-ec2-integration.ts
+++ b/test/modules/aws-ec2-integration.ts
@@ -196,15 +196,21 @@ describe('EC2 Integration Testing', () => {
     WHERE tags ->> 'name' = '${prefix}-nosg';
   `, (res: any[]) => expect(res.length).toBe(1)));
 
-  it('deletes both ec2 instances', query(`
-    DELETE FROM instance;
+  it('deletes all ec2 instances', query(`
+    DELETE FROM instance
+    WHERE tags ->> 'name' = '${prefix}-nosg' OR
+      tags ->> 'name' = '${prefix}-1' OR
+      tags ->> 'name' = '${prefix}-2';
   `));
 
   it('applies the instances deletion', apply());
 
   it('check number of instances', query(`
     SELECT *
-    FROM instance;
+    FROM instance
+    WHERE tags ->> 'name' = '${prefix}-nosg' OR
+      tags ->> 'name' = '${prefix}-1' OR
+      tags ->> 'name' = '${prefix}-2';
   `, (res: any[]) => expect(res.length).toBe(0)));
 
   it('deletes the test db', (done) => void iasql


### PR DESCRIPTION
Right now if you create an instance and do not defined security groups it enters into a loop trying to stabilize. The `default` security group is added by AWS if no security group was defined. We need to update the database properly based on the newly created cloud object to avoid this looping.