### PR TITLE
Ignore broken cloud records

### DIFF
--- a/src/modules/0.0.9/aws_cloudwatch/index.ts
+++ b/src/modules/0.0.9/aws_cloudwatch/index.ts
@@ -8,7 +8,7 @@ export const AwsCloudwatchModule: Module2 = new Module2({
   utils: {
     logGroupMapper: (lg: any) => {
       const out = new LogGroup();
-      if (!lg?.logGroupName) throw new Error('No log group name defined');
+      if (!lg?.logGroupName) return undefined;
       out.logGroupName = lg.logGroupName;
       out.logGroupArn = lg.arn;
       out.creationTime = lg.creationTime ? new Date(lg.creationTime) : lg.creationTime;

--- a/src/modules/0.0.9/aws_ec2_metadata/index.ts
+++ b/src/modules/0.0.9/aws_ec2_metadata/index.ts
@@ -12,7 +12,8 @@ export const AwsEc2MetadataModule: Module2 = new Module2({
     instanceMetadataMapper: async (instance: AWSInstance, ctx: Context) => {
       const client = await ctx.getAwsClient() as AWS;
       const out = new InstanceMetadata();
-      out.instanceId = instance.InstanceId ?? '';
+      if (!instance.InstanceId) return undefined;
+      out.instanceId = instance.InstanceId;
       // fill join column which is the id from the `instance` table
       const ins = await AwsEc2Module.mappers.instance.db.read(
         ctx,
@@ -20,11 +21,13 @@ export const AwsEc2MetadataModule: Module2 = new Module2({
       );
       out.id = ins.id;
       out.architecture = instance.Architecture as Architecture;
-      out.privateIpAddress = instance.PrivateIpAddress ?? '';
+      if (!instance.PrivateIpAddress) return undefined;
+      out.privateIpAddress = instance.PrivateIpAddress;
       out.launchTime = instance.LaunchTime as Date;
       out.spot = instance.InstanceLifecycle === 'spot';
       out.cpuCores = instance.CpuOptions?.CoreCount as number;
-      const instanceType = await client.getInstanceType(instance.InstanceType ?? '');
+      if (!instance.InstanceType) return undefined;
+      const instanceType = await client.getInstanceType(instance.InstanceType);
       out.memSizeMB = instanceType?.MemoryInfo?.SizeInMiB as number;
       return out;
     },

--- a/src/modules/0.0.9/aws_ecr/index.ts
+++ b/src/modules/0.0.9/aws_ecr/index.ts
@@ -12,7 +12,7 @@ export const AwsEcrModule: Module2 = new Module2({
   utils: {
     publicRepositoryMapper: (r: PublicRepositoryAws) => {
       const out = new PublicRepository();
-      if (!r?.repositoryName) throw new Error('No repository name defined.');
+      if (!r?.repositoryName) return undefined;
       out.repositoryName = r.repositoryName;
       out.repositoryArn = r.repositoryArn;
       out.registryId = r.registryId;
@@ -22,7 +22,7 @@ export const AwsEcrModule: Module2 = new Module2({
     },
     repositoryMapper: (r: RepositoryAws) => {
       const out = new Repository();
-      if (!r?.repositoryName) throw new Error('No repository name defined.');
+      if (!r?.repositoryName) return undefined;
       out.repositoryName = r.repositoryName;
       out.repositoryArn = r.repositoryArn;
       out.registryId = r.registryId;

--- a/src/modules/0.0.9/aws_elb/index.ts
+++ b/src/modules/0.0.9/aws_elb/index.ts
@@ -31,9 +31,7 @@ export const AwsElbModule: Module2 = new Module2({
   utils: {
     listenerMapper: async (l: ListenerAws, ctx: Context) => {
       const out = new Listener();
-      if (!l?.LoadBalancerArn || !l?.Port) {
-        throw new Error('Listerner not defined properly');
-      }
+      if (!l?.LoadBalancerArn || !l?.Port) return undefined;
       out.listenerArn = l?.ListenerArn;
       out.loadBalancer = ctx.memo?.db?.LoadBalancer?.[l.LoadBalancerArn] ?? await AwsElbModule.mappers.loadBalancer.db.read(ctx, l?.LoadBalancerArn);
       out.port = l?.Port;
@@ -57,7 +55,7 @@ export const AwsElbModule: Module2 = new Module2({
     loadBalancerMapper: async (lb: LoadBalancerAws, ctx: Context) => {
       const out = new LoadBalancer();
       if (!lb?.LoadBalancerName || !lb?.Scheme || !lb?.Type || !lb?.IpAddressType || !lb.VpcId) {
-        throw new Error('Load balancer not defined properly');
+        return undefined;
       }
       out.loadBalancerName = lb.LoadBalancerName;
       out.loadBalancerArn = lb.LoadBalancerArn;
@@ -91,9 +89,7 @@ export const AwsElbModule: Module2 = new Module2({
     },
     targetGroupMapper: async (tg: any, ctx: Context) => {
       const out = new TargetGroup();
-      if (!tg?.TargetGroupName) {
-        throw new Error('Target group not defined properly');
-      }
+      if (!tg?.TargetGroupName) return undefined;
       out.targetGroupName = tg.TargetGroupName;
       out.targetType = tg.TargetType as TargetTypeEnum;
       out.targetGroupArn = tg.TargetGroupArn;

--- a/src/modules/0.0.9/aws_iam/index.ts
+++ b/src/modules/0.0.9/aws_iam/index.ts
@@ -11,9 +11,11 @@ export const AwsIamModule: Module2 = new Module2({
     roleMapper: (role: AWSRole) => {
       const out = new Role();
       out.arn = role.Arn;
-      out.roleName = role.RoleName ?? '';
+      if (!role.RoleName) return undefined;
+      out.roleName = role.RoleName;
       out.description = role.Description ?? '';
-      out.assumeRolePolicyDocument = decodeURIComponent(role.AssumeRolePolicyDocument ?? '');
+      if (!role.AssumeRolePolicyDocument) return undefined;
+      out.assumeRolePolicyDocument = decodeURIComponent(role.AssumeRolePolicyDocument);
       return out;
     },
     roleNameFromArn: (arn: string, _ctx: Context) => {

--- a/src/modules/0.0.9/aws_route53_hosted_zones/index.ts
+++ b/src/modules/0.0.9/aws_route53_hosted_zones/index.ts
@@ -32,14 +32,14 @@ export const AwsRoute53HostedZoneModule: Module2 = new Module2({
     },
     hostedZoneMapper: (hz: any) => {
       const out = new HostedZone();
-      if (!hz?.Id) throw new Error('No HostedZoneId defined');
+      if (!hz?.Id) return undefined;
       out.hostedZoneId = hz.Id;
       out.domainName = hz.Name;
       return out;
     },
     resourceRecordSetMapper: async (rrs: any, ctx: Context) => {
       const out = new ResourceRecordSet();
-      if (!(rrs.Name && rrs.Type)) throw new Error('Wrong record from AWS');
+      if (!(rrs.Name && rrs.Type)) return undefined;
       out.parentHostedZone = await AwsRoute53HostedZoneModule.mappers.hostedZone.db.read(ctx, rrs.HostedZoneId) ??
         await AwsRoute53HostedZoneModule.mappers.hostedZone.cloud.read(ctx, rrs.HostedZoneId);
       if (!out.parentHostedZone) throw new Error('Hosted zone need to be loaded.');

--- a/src/modules/0.0.9/aws_s3/index.ts
+++ b/src/modules/0.0.9/aws_s3/index.ts
@@ -24,9 +24,10 @@ export const AwsS3Module: Module2 = new Module2({
           const allBuckets = await client.getBuckets();
           return allBuckets
             .filter(b => !id || b.Name === id)
+            .filter(b => !!b.Name)
             .map(b => {
               const bucket = new Bucket();
-              bucket.name = b.Name ?? '';
+              bucket.name = b.Name ?? ''; // The filter above is guarding this but TS is confused
               bucket.createdAt = b.CreationDate;
               return bucket;
             });

--- a/src/modules/0.0.9/aws_vpc/index.ts
+++ b/src/modules/0.0.9/aws_vpc/index.ts
@@ -26,11 +26,10 @@ export const AwsVpcModule: Module2 = new Module2({
   utils: {
     subnetMapper: async (sn: AwsSubnet, ctx: Context) => {
       const out = new Subnet();
-      if (!sn?.SubnetId || !sn?.VpcId) {
-        throw new Error('Subnet not defined properly');
-      }
+      if (!sn?.SubnetId || !sn?.VpcId) return undefined;
       out.state = sn.State as SubnetState;
-      out.availabilityZone = (sn.AvailabilityZone ?? '') as AvailabilityZone;
+      if (!sn.AvailabilityZone) return undefined;
+      out.availabilityZone = sn.AvailabilityZone as AvailabilityZone;
       out.vpc = await AwsVpcModule.mappers.vpc.db.read(ctx, sn.VpcId) ??
         await AwsVpcModule.mappers.vpc.cloud.read(ctx, sn.VpcId);
       if (sn.VpcId && !out.vpc) throw new Error(`Waiting for VPC ${sn.VpcId}`);
@@ -46,9 +45,7 @@ export const AwsVpcModule: Module2 = new Module2({
     },
     vpcMapper: (vpc: AwsVpc) => {
       const out = new Vpc();
-      if (!vpc?.VpcId || !vpc?.CidrBlock) {
-        throw new Error('VPC not defined properly');
-      }
+      if (!vpc?.VpcId || !vpc?.CidrBlock) return undefined;
       out.vpcId = vpc.VpcId;
       out.cidrBlock = vpc.CidrBlock;
       out.state = vpc.State as VpcState;
@@ -58,7 +55,7 @@ export const AwsVpcModule: Module2 = new Module2({
     elasticIpMapper: (eip: any) => {
       const out = new ElasticIp();
       out.allocationId = eip.AllocationId;
-      if (!out.allocationId) throw new Error('AWS should assign an AllocationId, this must not happen!');
+      if (!out.allocationId) return undefined;
       out.publicIp = eip.PublicIp;
       const tags: { [key: string]: string } = {};
       (eip.Tags || []).filter((t: any) => !!t.Key && !!t.Value).forEach((t: any) => {


### PR DESCRIPTION
Resolves #743

Places where the values provided by the AWS gateway are not present instead trigger the mappers to return undefined. Places where the Database does not yet have the value are still thrown errors to trigger a retry. This is still WIP as it needs to be thoroughly tested, but this is the approach I have waiting for review / double-checking