### PR TITLE
Disabled aws_ecs_simplified for now

### DIFF
--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -730,6 +730,7 @@ export async function modules(all: boolean, installed: boolean, dbId: string) {
   const Modules = (AllModules as any)[versionString];
   const allModules = Object.values(Modules)
     .filter((m: any) => m.hasOwnProperty('mappers') && m.hasOwnProperty('name') && !/iasql_.*/.test(m.name))
+    .filter((m: any) => process.env.IASQL_ENV !== 'production' && !/aws_ecs_simplified.*/.test(m.name)) // Temporarily disable ecs_simplified in production
     .map((m: any) => ({
       moduleName: m.name,
       moduleVersion: m.version,


### PR DESCRIPTION
Until #459 is done, `aws_ecs_simplified` clashes with the low-level modules (ECS, ECR, ELB, etc) in nasty ways that if both were installed simultaneously would cause chaos on `iasql_apply`.

So we're disabling it for now until we can safely revive it.