### PR TITLE
Remove `aws_acm_list` dependency from `aws_acm_import`

### DIFF
--- a/src/modules/0.0.8/aws_acm_import/index.ts
+++ b/src/modules/0.0.8/aws_acm_import/index.ts
@@ -30,7 +30,12 @@ export const AwsAcmImportModule: Module2 = new Module2({
             if (!importedCertArn) throw new Error('Error importing certificate');
             const importedCert = await AwsAcmListModule.mappers.certificate.cloud.read(ctx, importedCertArn);
             await AwsAcmImportModule.mappers.certificateImport.db.delete(e, ctx);
-            await AwsAcmListModule.mappers.certificate.db.create(importedCert, ctx);
+            try {
+              await AwsAcmListModule.mappers.certificate.db.create(importedCert, ctx);
+            } catch (e) {
+              // Do nothing
+              // AwsAcmListModule could not be installed and that's ok since there's no table dependency between them
+            }
           }
         },
         read: async () => { return; },

--- a/src/modules/0.0.8/aws_acm_import/module.json
+++ b/src/modules/0.0.8/aws_acm_import/module.json
@@ -1,4 +1,4 @@
 {
   "name": "aws_acm_import",
-  "dependencies": ["iasql_platform", "aws_account", "aws_acm_list"]
+  "dependencies": ["iasql_platform", "aws_account"]
 }


### PR DESCRIPTION
Resolves #764 

Remove unnecessary dependency that could lead to a broken state of the database.

This is because is more a "support" module than a real dependency. `aws_acm_import` could work perfectly without having `aws_acm_list`installed since there are no database relationships between them. They just share some cloud logic.