### PR TITLE
remove register event

### DIFF
--- a/src/services/repositories/metadata.ts
+++ b/src/services/repositories/metadata.ts
@@ -93,7 +93,6 @@ class MetadataRepo {
     const user = await this.userRepo.findOne(a0Id);
     if (!user) {
       // create the new user
-      telemetry.logUserRegister(a0Id, email);
       const newUser = new IasqlUser();
       newUser.id = a0Id;
       newUser.email = email;

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -63,22 +63,6 @@ export async function logDbConnectErr(dbId: string, uid: string, email: string, 
   await logDbErr('CONNECT', dbId, uid, email, error);
 }
 
-export async function logUserRegister(uid: string, email: string) {
-  if (!singleton) return;
-  try {
-    await singleton.logEvent({
-      user_id: uid,
-      event_type: 'REGISTER',
-      user_properties: {
-        email,
-        iasqlEnv: IASQL_ENV,
-      },
-    });
-  } catch(e: any) {
-    logger.error('failed to log REGISTER event', e);
-  }
-}
-
 export async function logDbDisconnect(dbId: string, userProp: UserProps) {
   await logDbEvent(dbId, userProp, 'DISCONNECT');
 }


### PR DESCRIPTION
in the new data model for analytics, we are tracking the user as the database so the register event is simply the connect event. the metadata repository still preserves the information