### PR TITLE
Create a temporary restricted user for the sql REST endpoint and free it out-of-band

### DIFF
--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -14,7 +14,7 @@ const config: ConfigInterface = {
     password: process.env.DB_PASSWORD ?? throwError('No DB Password defined'),
     port: 5432,
     forceSSL: true,
-    sqlViaRest: false,
+    sqlViaRest: true,
   },
   logger: {
     debug: true,

--- a/src/services/db-manager.ts
+++ b/src/services/db-manager.ts
@@ -67,6 +67,7 @@ export function grantPostgresRoleQuery(user: string) {
 
 export function dropPostgresRoleQuery(user: string) {
   return `
+    DROP OWNED BY ${user};
     DROP ROLE IF EXISTS ${user};
   `;
 }


### PR DESCRIPTION
Resolves #849 and unblocks safe production usage of the "run sql" path.