### PR TITLE
Only run the drop command on ephemeral accounts locally

### DIFF
--- a/src/config/ci.ts
+++ b/src/config/ci.ts
@@ -15,6 +15,7 @@ const config: ConfigInterface = {
     port: 5432,
     forceSSL: false,
     sqlViaRest: true,
+    dropBeforeUserDeletion: true,
   },
   logger: {
     debug: true,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -15,6 +15,8 @@ export interface ConfigInterface {
     port: number;
     forceSSL: boolean;
     sqlViaRest: boolean; // Enables a REST endpoint to run SQL commands via HTTPS
+    dropBeforeUserDeletion: boolean; // This config shouldn't need to exist, but weird difference
+                                     // in behavior between Postgres locally and in RDS
   };
   // Configuration for server logging
   logger: {

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -15,6 +15,7 @@ const config: ConfigInterface = {
     port: 5432,
     forceSSL: false,
     sqlViaRest: true,
+    dropBeforeUserDeletion: true,
   },
   logger: {
     debug: true,

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -16,6 +16,7 @@ const config: ConfigInterface = {
     port: 5432,
     forceSSL: true,
     sqlViaRest: true,
+    dropBeforeUserDeletion: false,
   },
   logger: {
     debug: true,

--- a/src/config/staging.ts
+++ b/src/config/staging.ts
@@ -16,6 +16,7 @@ const config: ConfigInterface = {
     port: 5432,
     forceSSL: true,
     sqlViaRest: true,
+    dropBeforeUserDeletion: false,
   },
   logger: {
     debug: true,

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -15,6 +15,7 @@ const config: ConfigInterface = {
     port: 5432,
     forceSSL: false,
     sqlViaRest: false,
+    dropBeforeUserDeletion: true,
   },
   logger: {
     debug: false,

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -188,7 +188,7 @@ export async function runSql(dbAlias: string, uid: string, sql: string) {
       // There's some weird latency between when this connection is closed and when Postgres is
       // actually done with the user, so let's sleep a second and then continue
       await new Promise(r => setTimeout(r, 1000));
-      await connMain.query(dbMan.dropPostgresRoleQuery(user, true));
+      await connMain.query(dbMan.dropPostgresRoleQuery(user, config.db.dropBeforeUserDeletion));
       await connMain.close();
     }, 1);
   }


### PR DESCRIPTION
After testing in staging and production, another anomaly has been detected where the resource dropping step necessary when running locally doesn't seem to apply and actually causes a crash.

The reason for this difference between the environments is unknown, but may be related to AWS's light forking of the OSS databases they run in RDS? In any case, this should eliminate the sentry report on this and prevent the postgres server from filling up with garbage users.