### PR TITLE
Verify disconnect works for old and busted databases

### DIFF
--- a/src/config/ci.ts
+++ b/src/config/ci.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.9',
-    oldestVersion: '0.0.5',
+    oldestVersion: '0.0.6',
   },
   db: {
     host: 'postgresql',

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.9',
-    oldestVersion: '0.0.5',
+    oldestVersion: '0.0.6',
   },
   db: {
     host: 'postgresql',

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.8',
-    oldestVersion: '0.0.5',
+    oldestVersion: '0.0.6',
   },
   db: {
     host: 'db.iasql.com',

--- a/src/config/staging.ts
+++ b/src/config/staging.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.9',
-    oldestVersion: '0.0.5',
+    oldestVersion: '0.0.6',
   },
   db: {
     host: 'db-staging.iasql.com',

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.9',
-    oldestVersion: '0.0.5',
+    oldestVersion: '0.0.6',
   },
   db: {
     host: 'localhost',

--- a/src/services/db-manager.ts
+++ b/src/services/db-manager.ts
@@ -4,12 +4,14 @@ import { Connection, } from 'typeorm'
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions'
 
 import config from '../config'
-import { latest, } from '../modules'
-
-const { IasqlPlatform, IasqlFunctions, } = latest;
-const version = IasqlPlatform.version;
+import * as Modules from '../modules'
 
 export async function migrate(conn: Connection) {
+  // Needs to be done this way or a redeploy would accidentally start using the next version even
+  // if it is not yet enabled.
+  const ModuleSet = (Modules as any)[`v${config.modules.latestVersion.replace(/\./g, '_')}`]
+  const { IasqlPlatform, IasqlFunctions, } = ModuleSet;
+  const version = IasqlPlatform.version;
   const qr = conn.createQueryRunner();
   await qr.connect();
   await IasqlPlatform.migrations.install(qr);


### PR DESCRIPTION
Resolves #860

Also fixes an issue with creating a new database with the wrong migrations if the `latest` variable in the Modules export doesn't match `latestVersion` in the environment in question.

TODO: Eliminate all uses in the codebase of the `latest` export, though the rest *probably* aren't as big of a deal.