### PR TITLE
Force test exit and do not error on misconfigured resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: CI
 # events but only for the main branch.
 on:
   push:
-    branches: [main]
+    branches: [main, debug-tests]
   pull_request:
     branches: [main]
 
@@ -61,17 +61,21 @@ jobs:
     outputs:
       test-modules: ${{ steps['set-test-modules'].outputs['test-modules'] }}
       set-test-module-names: ${{ steps['set-test-module-names'].outputs['test-module-names'] }}
-      region: ${{ steps['set-region'].outputs['region'] }}
+      # region: ${{ steps['set-region'].outputs['region'] }}
+      region: ap-northeast-1
     steps:
       - uses: actions/checkout@v2
       - run: yarn
       - id: set-test-modules
         name: Set modules tests
+        # run: >
+        #   echo "::set-output name=test-modules::$(npx jest **/modules/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')"
         run: >
-          echo "::set-output name=test-modules::$(npx jest **/modules/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')"
+          echo "::set-output name=test-modules::$(npx jest **/modules/*ecs* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')"
       - id: set-test-module-names
         name: Set modules tests names
-        run: echo "::set-output name=test-module-names::$(npx jest **/modules/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
+        # run: echo "::set-output name=test-module-names::$(npx jest **/modules/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
+        run: echo "::set-output name=test-module-names::$(npx jest **/modules/*ecs* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
       - id: set-region
         name: Set region
         # All regions except us-east-1 to not collide with common tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: CI
 # events but only for the main branch.
 on:
   push:
-    branches: [main, debug-tests]
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -61,21 +61,17 @@ jobs:
     outputs:
       test-modules: ${{ steps['set-test-modules'].outputs['test-modules'] }}
       set-test-module-names: ${{ steps['set-test-module-names'].outputs['test-module-names'] }}
-      # region: ${{ steps['set-region'].outputs['region'] }}
-      region: ap-northeast-1
+      region: ${{ steps['set-region'].outputs['region'] }}
     steps:
       - uses: actions/checkout@v2
       - run: yarn
       - id: set-test-modules
         name: Set modules tests
-        # run: >
-        #   echo "::set-output name=test-modules::$(npx jest **/modules/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')"
         run: >
-          echo "::set-output name=test-modules::$(npx jest **/modules/*ecs* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')"
+          echo "::set-output name=test-modules::$(npx jest **/modules/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')"
       - id: set-test-module-names
         name: Set modules tests names
-        # run: echo "::set-output name=test-module-names::$(npx jest **/modules/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
-        run: echo "::set-output name=test-module-names::$(npx jest **/modules/*ecs* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
+        run: echo "::set-output name=test-module-names::$(npx jest **/modules/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
       - id: set-region
         name: Set region
         # All regions except us-east-1 to not collide with common tests

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf dist",
     "lint": "tslint --project .",
     "test": "IASQL_ENV=test jest -i",
-    "coverage": "IASQL_ENV=test jest -i --coverage",
+    "coverage": "IASQL_ENV=test jest -i --coverage --forceExit --detectOpenHandles",
     "coverage:local": "IASQL_ENV=test export $(cat .env | xargs) && yarn coverage",
     "serve": "node --max_old_space_size=8192 dist/index.js",
     "start": "yarn serve",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf dist",
     "lint": "tslint --project .",
     "test": "IASQL_ENV=test jest -i",
-    "coverage": "IASQL_ENV=test jest -i --coverage --forceExit --detectOpenHandles",
+    "coverage": "IASQL_ENV=test jest -i --coverage --forceExit",
     "coverage:local": "IASQL_ENV=test export $(cat .env | xargs) && yarn coverage",
     "serve": "node --max_old_space_size=8192 dist/index.js",
     "start": "yarn serve",

--- a/src/modules/0.0.9/aws_elb/entity/listener.ts
+++ b/src/modules/0.0.9/aws_elb/entity/listener.ts
@@ -58,7 +58,10 @@ export class Listener {
   })
   actionType: ActionTypeEnum;
 
-  @ManyToOne(() => TargetGroup, { eager: true })
+  @ManyToOne(() => TargetGroup, {
+    nullable:false,
+    eager: true
+  })
   @JoinColumn({
     name: 'target_group_name',
   })

--- a/src/modules/0.0.9/aws_elb/index.ts
+++ b/src/modules/0.0.9/aws_elb/index.ts
@@ -41,7 +41,7 @@ export const AwsElbModule: Module2 = new Module2({
           out.actionType = (a.Type as ActionTypeEnum);
           out.targetGroup =  await AwsElbModule.mappers.targetGroup.db.read(ctx, a?.TargetGroupArn) ??
             await AwsElbModule.mappers.targetGroup.cloud.read(ctx, a?.TargetGroupArn);
-          if (!out.targetGroup) throw new Error('Target groups need to be loaded first');
+          if (!out.targetGroup) return undefined;
         }
       }
       if (l.SslPolicy && l.Certificates?.length) {
@@ -76,8 +76,7 @@ export const AwsElbModule: Module2 = new Module2({
           continue;
         }
       }
-      if (securityGroups.filter(sg => !!sg).length !== cloudSecurityGroups.length) throw new Error('Security groups need to be loaded first')
-      out.securityGroups = securityGroups;
+      out.securityGroups = securityGroups.filter(sg => !!sg);
       out.ipAddressType = lb.IpAddressType as IpAddressType;
       out.customerOwnedIpv4Pool = lb.CustomerOwnedIpv4Pool;
       const vpc = await AwsVpcModule.mappers.vpc.db.read(ctx, lb.VpcId) ??

--- a/src/modules/0.0.9/aws_elb/migration/1655822977761-aws_elb.ts
+++ b/src/modules/0.0.9/aws_elb/migration/1655822977761-aws_elb.ts
@@ -1,7 +1,7 @@
 import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class awsElb1654619715201 implements MigrationInterface {
-    name = 'awsElb1654619715201'
+export class awsElb1655822977761 implements MigrationInterface {
+    name = 'awsElb1655822977761'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TYPE "public"."load_balancer_scheme_enum" AS ENUM('internal', 'internet-facing')`);
@@ -17,7 +17,7 @@ export class awsElb1654619715201 implements MigrationInterface {
         await queryRunner.query(`CREATE TABLE "target_group" ("target_group_name" character varying NOT NULL, "target_type" "public"."target_group_target_type_enum" NOT NULL, "target_group_arn" character varying, "ip_address_type" "public"."target_group_ip_address_type_enum", "protocol" "public"."target_group_protocol_enum", "port" integer, "health_check_protocol" "public"."target_group_health_check_protocol_enum", "health_check_port" character varying, "health_check_enabled" boolean, "health_check_interval_seconds" integer, "health_check_timeout_seconds" integer, "healthy_threshold_count" integer, "unhealthy_threshold_count" integer, "health_check_path" character varying, "protocol_version" "public"."target_group_protocol_version_enum", "vpc" integer, CONSTRAINT "PK_1957da369918349223c6d3c01b0" PRIMARY KEY ("target_group_name"))`);
         await queryRunner.query(`CREATE TYPE "public"."listener_protocol_enum" AS ENUM('GENEVE', 'HTTP', 'HTTPS', 'TCP', 'TCP_UDP', 'TLS', 'UDP')`);
         await queryRunner.query(`CREATE TYPE "public"."listener_action_type_enum" AS ENUM('forward')`);
-        await queryRunner.query(`CREATE TABLE "listener" ("id" SERIAL NOT NULL, "listener_arn" character varying, "port" integer NOT NULL, "protocol" "public"."listener_protocol_enum" NOT NULL, "action_type" "public"."listener_action_type_enum" NOT NULL DEFAULT 'forward', "ssl_policy" character varying, "load_balancer_name" character varying NOT NULL, "target_group_name" character varying, "certificate_id" integer, CONSTRAINT "UQ_load_balancer__port" UNIQUE ("load_balancer_name", "port"), CONSTRAINT "PK_422c9d250eb7b0c0b6c96cdce94" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "listener" ("id" SERIAL NOT NULL, "listener_arn" character varying, "port" integer NOT NULL, "protocol" "public"."listener_protocol_enum" NOT NULL, "action_type" "public"."listener_action_type_enum" NOT NULL DEFAULT 'forward', "ssl_policy" character varying, "load_balancer_name" character varying NOT NULL, "target_group_name" character varying NOT NULL, "certificate_id" integer, CONSTRAINT "UQ_load_balancer__port" UNIQUE ("load_balancer_name", "port"), CONSTRAINT "PK_422c9d250eb7b0c0b6c96cdce94" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TABLE "load_balancer_security_groups" ("load_balancer_name" character varying NOT NULL, "security_group_id" integer NOT NULL, CONSTRAINT "PK_c3263aa4b606967900de62e3619" PRIMARY KEY ("load_balancer_name", "security_group_id"))`);
         await queryRunner.query(`CREATE INDEX "IDX_e1020e4ee5063ea1f0b20b3c9c" ON "load_balancer_security_groups" ("load_balancer_name") `);
         await queryRunner.query(`CREATE INDEX "IDX_4da7e08287b5693e5b22959ced" ON "load_balancer_security_groups" ("security_group_id") `);

--- a/src/services/gateways/aws_2.ts
+++ b/src/services/gateways/aws_2.ts
@@ -482,13 +482,13 @@ export class AWS {
 
   async deleteSecurityGroup(instanceParams: DeleteSecurityGroupRequest) {
     try {
-      return this.ec2client.deleteSecurityGroup(instanceParams);
+      return await this.ec2client.deleteSecurityGroup(instanceParams);
     } catch(e: any) {
       if (e.Code === 'DependencyViolation') {
         // Just wait for 5 min on every dependency violation and retry
         await new Promise(resolve => setTimeout(resolve, 5 * 60 * 1000));
         try {
-          return this.ec2client.deleteSecurityGroup(instanceParams);
+          return await this.ec2client.deleteSecurityGroup(instanceParams);
         } catch (e2: any) {
           // If the dependency continues we add the dependency to the error message in order to debug what is happening
           if (e2.Code === 'DependencyViolation') {


### PR DESCRIPTION
The test suite is getting hanged up sometimes because the engine workers keep trying to connect with the database that is already down. Here is an example:https://github.com/iasql/iasql-engine/runs/6981051342?check_suite_focus=true#step:5:5695

We have to look deeper in that error, but for now we force jest to exit so we avoid long running tests that already failed.

Also, ignore some misconfigured resources instead of throwing an error.