### PR TITLE
type and simplify telemetry api

### DIFF
--- a/src/router/db.ts
+++ b/src/router/db.ts
@@ -26,17 +26,17 @@ db.get('/connect/:dbAlias', async (req, res) => {
       dbAlias, uid, email, dbId
     );
     res.json(database);
-    telemetry.logDbConnect(dbId, {
+    telemetry.logConnect({
       dbAlias,
       uid,
       email,
       recordCount: database.recordCount,
       operationCount: database.operationCount
-    });
+    }, {}, dbId);
   } catch (e) {
-    const err = logUserErr(e, uid, email, dbAlias);
-    res.status(500).end(err);
-    telemetry.logDbConnectErr(dbId, uid, email, err);
+    const error = logUserErr(e, uid, email, dbAlias);
+    res.status(500).end(error);
+    telemetry.logConnect({ uid, email }, { error }, dbId);
   }
 });
 
@@ -56,17 +56,17 @@ db.post('/connect', async (req, res) => {
       dbAlias, uid, email, dbId
     );
     res.json(database);
-    telemetry.logDbConnect(dbId, {
+    telemetry.logConnect({
       dbAlias,
       uid,
       email,
       recordCount: database.recordCount,
       operationCount: database.operationCount
-    });
+    }, {}, dbId);
   } catch (e) {
-    const err = logUserErr(e, uid, email, dbAlias);
-    res.status(500).end(err);
-    telemetry.logDbConnectErr(dbId, uid, email, err);
+    const error = logUserErr(e, uid, email, dbAlias);
+    res.status(500).end(error);
+    telemetry.logConnect({ uid, email },  { error }, dbId);
   }
 });
 
@@ -97,13 +97,13 @@ db.post('/export', async (req, res) => {
   try {
     const database: IasqlDatabase = await MetadataRepo.getDb(uid, dbAlias);
     res.send(await iasql.dump(database.pgName, !!dataOnly));
-    telemetry.logDbExport(database.pgName, {
+    telemetry.logExport({
       dbAlias,
       email,
       uid,
       recordCount: database.recordCount,
       operationCount: database.operationCount,
-    }, !!dataOnly);
+    }, { dataOnly: !!dataOnly }, database.pgName);
   } catch (e) {
     res.status(500).end(logUserErr(e, uid, email, dbAlias));
   }
@@ -129,16 +129,16 @@ db.get('/disconnect/:dbAlias', async (req, res) => {
   const email = dbMan.getEmail(req.user);
   try {
     const dbId = await iasql.disconnect(dbAlias, uid);
-    telemetry.logDbDisconnect(dbId, {
+    telemetry.logDisconnect({
       dbAlias,
       email,
       uid
-    });
+    }, {}, dbId);
     res.json(`disconnected ${dbAlias}`);
   } catch (e) {
-    const err = logUserErr(e, uid, email, dbAlias);
-    res.status(500).end(err);
-    telemetry.logDbDisconnectErr(uid, email, err);
+    const error = logUserErr(e, uid, email, dbAlias);
+    res.status(500).end(error);
+    telemetry.logDisconnect({ uid, email }, { error });
   }
 });
 
@@ -149,10 +149,25 @@ db.post('/run/:dbAlias', async (req, res) => {
   const sql = req.body;
   const uid = dbMan.getUid(req.user);
   const email = dbMan.getEmail(req.user);
+  let dbId;
   try {
-    const out = await iasql.runSql(dbAlias, uid, sql);
-    res.json(out);
-  } catch (e) {
-    res.status(500).end(logUserErr(e, uid, email, dbAlias));
+    const database: IasqlDatabase = await MetadataRepo.getDb(uid, dbAlias);
+    dbId = database.pgName;
+    const output = await iasql.runSql(dbAlias, uid, sql);
+    telemetry.logRunSql({
+      dbAlias,
+      email,
+      uid
+    }, {
+      output,
+      sql
+    }, database.pgName);
+    res.json(output);
+  } catch (e: any) {
+    // do not send to sentry
+    let error = e?.message ?? '';
+    logger.error(`RunSQL user error: ${error}`, { uid, email, dbAlias})
+    telemetry.logRunSql({ uid, email }, { error }, dbId);
+    res.status(500).end(error);
   }
 });

--- a/src/router/db.ts
+++ b/src/router/db.ts
@@ -167,7 +167,7 @@ db.post('/run/:dbAlias', async (req, res) => {
     // do not send to sentry
     const error = e?.message ?? '';
     logger.error(`RunSQL user error: ${error}`, { uid, email, dbAlias})
-    telemetry.logRunSql({ uid, email }, { error }, dbId);
+    telemetry.logRunSql({ uid, email }, { sql, error }, dbId);
     res.status(500).end(error);
   }
 });

--- a/src/router/db.ts
+++ b/src/router/db.ts
@@ -165,7 +165,7 @@ db.post('/run/:dbAlias', async (req, res) => {
     res.json(output);
   } catch (e: any) {
     // do not send to sentry
-    let error = e?.message ?? '';
+    const error = e?.message ?? '';
     logger.error(`RunSQL user error: ${error}`, { uid, email, dbAlias})
     telemetry.logRunSql({ uid, email }, { error }, dbId);
     res.status(500).end(error);

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -110,8 +110,8 @@ export async function start(dbId: string, dbUser:string) {
             const recordCount = await iasql.getDbRecCount(conn);
             const operationCount = await iasql.getOpCount(conn);
             await MetadataRepo.updateDbCounts(dbId, recordCount, operationCount);
-            telemetry.logDbOp(
-              dbId,
+            telemetry.logOp(
+              optype,
               {
                 uid,
                 email,
@@ -119,12 +119,12 @@ export async function start(dbId: string, dbUser:string) {
                 recordCount,
                 operationCount,
               },
-              optype,
               {
                 params,
                 output,
                 error,
-              }
+              },
+              dbId,
             );
           } catch(e: any) {
             logger.error('could not log op event', e);

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -1,4 +1,5 @@
 import * as Amplitude from '@amplitude/node'
+import * as sentry from '@sentry/node'
 
 import config, { IASQL_ENV } from '../config'
 import logger from './logger'
@@ -39,7 +40,13 @@ async function logEvent(event: string, dbProps: DbProps, eventProps?: EventProps
       event_properties: eventProps
     });
   } catch(e: any) {
-    logger.error(`failed to log ${event} event`, e);
+    const message = `failed to log ${event} event`;
+    if (config.sentry) {
+      sentry.captureException(e, {
+        extra: { message },
+      });
+    }
+    logger.error(message, e);
   }
 }
 


### PR DESCRIPTION
this fixes the bug we were seeing were the wrong `string` was used as an argument to the telemetry method

 this PR also changes stops sending `runSql` user errors to sentry