### PR TITLE
Add proper support for multiple query statements

### DIFF
--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -189,7 +189,7 @@ export async function runSql(dbAlias: string, uid: string, sql: string) {
     });
     await connTemp.connect();
     const out = await connTemp.query(sql);
-    // Let's make this a bit easier to parse. Error -> string, single table -> array of objects,
+    // Let's make this a bit easier to parse. Error -> error path, single table -> array of objects,
     // multiple tables -> array of array of objects
     if (typeof out === 'string') {
       return out;

--- a/test/modules/aws-account-integration.ts
+++ b/test/modules/aws-account-integration.ts
@@ -19,6 +19,7 @@ const apply = runApply.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
+const runSql = iasql.runSql.bind(null, dbAlias, dbAlias);
 
 jest.setTimeout(360000);
 beforeAll(async () => await execComposeUp());
@@ -45,6 +46,44 @@ describe('AwsAccount Integration Testing', () => {
     INSERT INTO aws_account (region, access_key_id, secret_access_key)
     VALUES ('us-east-1', '${process.env.AWS_ACCESS_KEY_ID}', '${process.env.AWS_SECRET_ACCESS_KEY}')
   `));
+
+  describe('runSql segue', () => {
+    it('confirms bad sql queries return an error string', (done) => {
+      (async () => {
+        if (typeof (await runSql('SELECT * FROM foo')) === 'string') {
+          done();
+        } else {
+          done(new Error('Unexpected response from error query'));
+        }
+      })();
+    });
+
+    it('confirms good sql queries return an array of records', (done) => {
+      (async () => {
+        const rows = await runSql('SELECT * FROM aws_account');
+        if (rows instanceof Array && rows[0].region === 'us-east-1') {
+          done();
+        } else {
+          done(new Error('Unexpected response from normal query'));
+        }
+      })();
+    });
+
+    it('confirms multiple sql queries returns an array of arrays of records', (done) => {
+      (async () => {
+        const results = await runSql('SELECT * FROM aws_account; SELECT * FROM iasql_help();');
+        if (
+          results instanceof Array &&
+          results[0] instanceof Array &&
+          (results[0] as any).region === 'us-east-1'
+        ) {
+          done();
+        } else {
+          done(new Error('Unexpected response from batch query'));
+        }
+      })();
+    });
+  });
 
   it('inserts a second, useless row into the aws_account table', query(`
     INSERT INTO aws_account (access_key_id, secret_access_key, region)


### PR DESCRIPTION
It was discovered that TypeORM's `query` method breaks if there are multiple SQL statements in the query. They are run correctly, but no response is returned, as it must not be able to handle the response provided by the postgres driver. So this PR just uses the `pg` library directly and does some light formatting to make the response more closely match the behavior of the `query` function before, which is also generally more intuitive than the metadata-filled objects `pg` returns by default.