### PR TITLE
initialize sentry within the scheduler child processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "gen-sql": "IASQL_ENV=ci ts-node ./node_modules/.bin/typeorm migration:generate -n",
     "migrate": "IASQL_ENV=ci ts-node ./node_modules/.bin/typeorm migration:run",
     "gen-module": "IASQL_ENV=ci ./.module_migration.sh",
+    "docker-compose:debug": "IASQL_ENV=ci docker-compose -f docker-compose.yml -f docker-compose.debug.yml up --build",
+    "docker-compose": "IASQL_ENV=local docker-compose up --build",
     "version": "./.version.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,9 @@
     "serve:debug": "node --inspect=0.0.0.0:9229 --max_old_space_size=8192 dist/index.js",
     "start": "yarn serve",
     "start:debug": "nodemon -e ts -w ./src -x yarn serve:debug",
-    "gen-sql": "IASQL_ENV=local ts-node ./node_modules/.bin/typeorm migration:generate -n",
-    "migrate": "IASQL_ENV=local ts-node ./node_modules/.bin/typeorm migration:run",
-    "gen-module": "IASQL_ENV=local ./.module_migration.sh",
-    "docker-compose:debug": "IASQL_ENV=local docker-compose -f docker-compose.yml -f docker-compose.debug.yml up --build",
-    "docker-compose": "IASQL_ENV=local docker-compose up --build",
+    "gen-sql": "IASQL_ENV=ci ts-node ./node_modules/.bin/typeorm migration:generate -n",
+    "migrate": "IASQL_ENV=ci ts-node ./node_modules/.bin/typeorm migration:run",
+    "gen-module": "IASQL_ENV=ci ./.module_migration.sh",
     "version": "./.version.sh"
   },
   "repository": {

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -1,4 +1,5 @@
 import { run } from 'graphile-worker'
+import * as sentry from '@sentry/node';
 import { v4 as uuidv4, } from 'uuid'
 
 import { latest, } from '../modules'
@@ -161,7 +162,9 @@ export async function stopAll() {
 
 // spin up a worker for every db that this server is already managing
 export async function init() {
-  if (!MetadataRepo.initialized) await MetadataRepo.init(); // Necessary in the child process
+  // Necessary in the child process
+  if (config.sentry) sentry.init(config.sentry);
+  if (!MetadataRepo.initialized) await MetadataRepo.init();
   const dbs: IasqlDatabase[] = await MetadataRepo.getAllDbs();
   const inits = await Promise.allSettled(dbs.map(db => start(db.pgName, db.pgUser)));
   for (const [i, bootstrap] of inits.entries()) {


### PR DESCRIPTION
Resolves #896 and surfaces errors to sentry for all iasql functions which were not getting surfaced.