### PR TITLE
Attempt to fix the doc generation trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         id: format-version
         run: |
           VERSION="$(echo ${{ github.event.ref }} | sed 's/v//g')"
-          echo ::set-output version=${VERSION}
+          echo ::set-output name=version::${VERSION}
       - name: Emit doc generation
         uses: mvasigh/dispatch-action@main
         with:


### PR DESCRIPTION
Based on my reading of: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs I think this is what I did wrong with this trigger before