### PR TITLE
Fix the response output when executing insert/update/delete sql commands

### DIFF
--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -193,6 +193,13 @@ export async function runSql(dbAlias: string, uid: string, sql: string) {
     // multiple tables -> array of array of objects
     if (typeof out === 'string') {
       return out;
+    } else if (
+      !!out.rows &&
+      out.rows.length === 0 &&
+      out.command !== 'SELECT' &&
+      typeof out.rowCount === 'number'
+    ) {
+      return [{ affected_records: out.rowCount, }];
     } else if (!!out.rows) {
       return out.rows;
     } else if (out instanceof Array) {


### PR DESCRIPTION
The engine provided a useless empty set when running non-SELECT commands before. The new logic detects this scenario and returns the affected record count in the same form as a query result, instead, to be more useful to end-users.

This resolves iasql/dashboard#147
This also resolves iasql/dashboard#171