### PR TITLE
Restore custom constraints to ec2 module

### DIFF
--- a/src/modules/0.0.14/aws_ec2/migration/1657324109020-aws_ec2.ts
+++ b/src/modules/0.0.14/aws_ec2/migration/1657324109020-aws_ec2.ts
@@ -1,5 +1,7 @@
 import {MigrationInterface, QueryRunner} from "typeorm";
 
+import * as sql from '../sql';
+
 export class awsEc21657324109020 implements MigrationInterface {
     name = 'awsEc21657324109020'
 
@@ -21,9 +23,11 @@ export class awsEc21657324109020 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "general_purpose_volume" ADD CONSTRAINT "FK_b60cd423a9b292b547913dcc6ac" FOREIGN KEY ("attached_instance_id") REFERENCES "instance"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "instance_security_groups" ADD CONSTRAINT "FK_fa3c179d5090cb1309c63b5e20a" FOREIGN KEY ("instance_id") REFERENCES "instance"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
         await queryRunner.query(`ALTER TABLE "instance_security_groups" ADD CONSTRAINT "FK_b3b92934eff56d2eb0477a1d27f" FOREIGN KEY ("security_group_id") REFERENCES "security_group"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(sql.createCustomConstraints);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(sql.dropCustomConstraints);
         await queryRunner.query(`ALTER TABLE "instance_security_groups" DROP CONSTRAINT "FK_b3b92934eff56d2eb0477a1d27f"`);
         await queryRunner.query(`ALTER TABLE "instance_security_groups" DROP CONSTRAINT "FK_fa3c179d5090cb1309c63b5e20a"`);
         await queryRunner.query(`ALTER TABLE "general_purpose_volume" DROP CONSTRAINT "FK_b60cd423a9b292b547913dcc6ac"`);

--- a/src/modules/0.0.14/aws_ec2/sql/create_custom_constraints.sql
+++ b/src/modules/0.0.14/aws_ec2/sql/create_custom_constraints.sql
@@ -30,11 +30,11 @@ $$;
 ALTER TABLE instance ADD CONSTRAINT check_role_ec2 CHECK (role_name is NULL OR (role_name is NOT NULL AND check_role_ec2(role_name)));
 
 -- Create EC2 instance and EBS volume must be in the same availability zone
-create or replace function check_instance_ebs_availability_zone(_instance_id integer, _ebs_availability_zone general_purpose_volume_availability_zone_enum) returns boolean
+create or replace function check_instance_ebs_availability_zone(_instance_id integer, _ebs_availability_zone character varying) returns boolean
 language plpgsql security definer
 as $$
 declare
-  _instance_availability_zone subnet_availability_zone_enum;
+  _instance_availability_zone character varying;
 begin
   select subnet.availability_zone into _instance_availability_zone
   from instance


### PR DESCRIPTION
While reading through the code to see how to add custom constraints for the load balancer entity, I realized that the custom constraints in the EC2 module had been accidentally dropped in a migration a couple of versions ago, so this restores that back.