### PR TITLE
Class-Based Modules, Part 1

### DIFF
--- a/src/modules/0.0.16/aws_account/index.ts
+++ b/src/modules/0.0.16/aws_account/index.ts
@@ -1,50 +1,48 @@
 import { AWS, } from '../../../services/aws_macros'
 import { AwsAccountEntity, } from './entity'
-import { Context, Crud2, Mapper2, Module2, } from '../../interfaces'
-import * as metadata from './module.json'
+import { Context, Crud2, Mapper2, ModuleBase, } from '../../interfaces'
+import * as metadata from './module.json' // TODO: Eliminate this?
 
-export const AwsAccount: Module2 = new Module2({
-  ...metadata,
-  provides: {
-    context: {
-      // This function is `async function () {` instead of `async () => {` because that enables the
-      // `this` keyword within the function based on the objec it is being called from, so the
-      // `getAwsClient` function can access the correct `orm` object with the appropriate creds and
-      // read out the right AWS creds and create an AWS client also attached to the current context,
-      // which will be different for different users. WARNING: Explicitly trying to access via
-      // `AwsAccount.provides.context.getAwsClient` would instead use the context *template* that is
-      // global to the codebase.
-      async getAwsClient() {
-        const orm = this.orm;
-        if (this.awsClient) return this.awsClient;
-        const awsCreds = await orm.findOne(AwsAccount.mappers.awsAccount.entity);
-        this.awsClient = new AWS({
-          region: awsCreds.region,
-          credentials: {
-            accessKeyId: awsCreds.accessKeyId,
-            secretAccessKey: awsCreds.secretAccessKey,
-          },
-        });
-        return this.awsClient;
-      },
-      awsClient: null, // Just reserving this name to guard against collisions between modules.
+class AwsAccount extends ModuleBase {
+  __dirname = __dirname;
+  dependencies = metadata.dependencies;
+  context: Context = {
+    // This function is `async function () {` instead of `async () => {` because that enables the
+    // `this` keyword within the function based on the objec it is being called from, so the
+    // `getAwsClient` function can access the correct `orm` object with the appropriate creds and
+    // read out the right AWS creds and create an AWS client also attached to the current context,
+    // which will be different for different users. WARNING: Explicitly trying to access via
+    // `AwsAccount.provides.context.getAwsClient` would instead use the context *template* that is
+    // global to the codebase.
+    async getAwsClient() {
+      const orm = this.orm;
+      if (this.awsClient) return this.awsClient;
+      const awsCreds = await orm.findOne(awsAccount.awsAccount.entity);
+      this.awsClient = new AWS({
+        region: awsCreds.region,
+        credentials: {
+          accessKeyId: awsCreds.accessKeyId,
+          secretAccessKey: awsCreds.secretAccessKey,
+        },
+      });
+      return this.awsClient;
     },
-  },
-  mappers: {
-    awsAccount: new Mapper2<AwsAccountEntity>({
-      entity: AwsAccountEntity,
-      equals: (_a: AwsAccountEntity, _b: AwsAccountEntity) => true,
-      source: 'db',
-      cloud: new Crud2({
-        create: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
-        read: (ctx: Context, id?: string) => ctx.orm.find(AwsAccountEntity, id ? {
-          where: {
-            id,
-          },
-        } : undefined),
-        update: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
-        delete: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
-      }),
+    awsClient: null, // Just reserving this name to guard against collisions between modules.
+  };
+  awsAccount = new Mapper2<AwsAccountEntity>({
+    entity: AwsAccountEntity,
+    equals: (_a: AwsAccountEntity, _b: AwsAccountEntity) => true,
+    source: 'db',
+    cloud: new Crud2({
+      create: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
+      read: (ctx: Context, id?: string) => ctx.orm.find(AwsAccountEntity, id ? {
+        where: {
+          id,
+        },
+      } : undefined),
+      update: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
+      delete: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
     }),
-  },
-}, __dirname);
+  });
+}
+export const awsAccount = new AwsAccount();

--- a/src/modules/0.0.16/aws_account/index.ts
+++ b/src/modules/0.0.16/aws_account/index.ts
@@ -16,8 +16,8 @@ class AwsAccount extends ModuleBase {
     // `AwsAccount.provides.context.getAwsClient` would instead use the context *template* that is
     // global to the codebase.
     async getAwsClient() {
-      const orm = this.orm;
       if (this.awsClient) return this.awsClient;
+      const orm = this.orm;
       const awsCreds = await orm.findOne(awsAccount.awsAccount.entity);
       this.awsClient = new AWS({
         region: awsCreds.region,

--- a/src/modules/0.0.16/aws_account/index.ts
+++ b/src/modules/0.0.16/aws_account/index.ts
@@ -4,6 +4,7 @@ import { Context, Crud2, Mapper2, ModuleBase, } from '../../interfaces'
 import * as metadata from './module.json' // TODO: Eliminate this?
 
 class AwsAccount extends ModuleBase {
+  constructor() { super(); super.init(); }
   dirname = __dirname;
   dependencies = metadata.dependencies;
   context: Context = {

--- a/src/modules/0.0.16/aws_account/index.ts
+++ b/src/modules/0.0.16/aws_account/index.ts
@@ -4,7 +4,7 @@ import { Context, Crud2, Mapper2, ModuleBase, } from '../../interfaces'
 import * as metadata from './module.json' // TODO: Eliminate this?
 
 class AwsAccount extends ModuleBase {
-  __dirname = __dirname;
+  dirname = __dirname;
   dependencies = metadata.dependencies;
   context: Context = {
     // This function is `async function () {` instead of `async () => {` because that enables the

--- a/src/modules/0.0.16/aws_ecs_simplified/index.ts
+++ b/src/modules/0.0.16/aws_ecs_simplified/index.ts
@@ -26,6 +26,7 @@ import { PublicRepository } from '../aws_ecr/entity'
 import cloudFns from './cloud_fns';
 import simplifiedMappers from './simplified_mappers';
 import { generateResourceName, processImageFromString } from './helpers';
+import { awsAccount, } from '../aws_account'
 
 export type SimplifiedObjectMapped = {
   securityGroup: SecurityGroup;
@@ -45,11 +46,23 @@ export type SimplifiedObjectMapped = {
 
 const prefix = 'iasql-ecs-';
 
+// TODO: remove this once the aws gateway gets disolved
+async function getAwsClient(ctx: Context): Promise<AWS> {
+  const awsCreds = await ctx?.orm?.findOne(awsAccount.awsAccount.entity);
+  return new AWS({
+    region: awsCreds.region,
+    credentials: {
+      accessKeyId: awsCreds.accessKeyId,
+      secretAccessKey: awsCreds.secretAccessKey,
+    },
+  });
+}
+
 export const AwsEcsSimplifiedModule: Module2 = new Module2({
   ...metadata,
   utils: {
     ecsSimplifiedMapper: async (e: AwsService, ctx: Context) => {
-      const client = await ctx.getAwsClient() as AWS;
+      const client = await getAwsClient(ctx) as AWS;
       const out = new EcsSimplified();
       out.appName = e.serviceName?.substring(e.serviceName.indexOf(prefix) + prefix.length, e.serviceName.indexOf('-svc')) ?? '';
       out.desiredCount = e.desiredCount ?? 1;
@@ -73,7 +86,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
       try {
         // We use the service name as the appName
         const appName = service.serviceName?.substring(service.serviceName.indexOf(prefix) + prefix.length, service.serviceName.indexOf('-svc')) ?? '';
-        const client = await ctx.getAwsClient() as AWS;
+        const client = await getAwsClient(ctx) as AWS;
         // Check if the cluster follow the name pattern
         const cluster = await client.getCluster(service.clusterArn ?? '');
         if (!Object.is(cluster?.clusterName, generateResourceName(prefix, appName, 'Cluster'))) return false;
@@ -194,7 +207,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
       source: 'db',
       cloud: new Crud2({
         create: async (es: EcsSimplified[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
+          const client = await getAwsClient(ctx) as AWS;
           const defaultVpc = await AwsEcsSimplifiedModule.utils.cloud.get.defaultVpc(client);
           const defaultSubnets = await AwsEcsSimplifiedModule.utils.cloud.get.defaultSubnets(client, defaultVpc.VpcId);
           const out: any[] = [];
@@ -294,7 +307,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
           return out;
         },
         read: async (ctx: Context, id?: string) => {
-          const client = await ctx.getAwsClient() as AWS;
+          const client = await getAwsClient(ctx) as AWS;
           // read all clusters and find the ones that match our pattern
           const clusters = await client.getClusters();
           const relevantClusters = clusters?.filter(c => c.clusterName?.includes(prefix)) ?? [];
@@ -325,7 +338,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
           return 'update';
         },
         update: async (es: EcsSimplified[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
+          const client = await getAwsClient(ctx) as AWS;
           const out = [];
           for (const e of es) {
             const cloudRecord = ctx?.memo?.cloud?.EcsSimplified?.[e.appName ?? ''];
@@ -396,7 +409,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
           return out;
         },
         delete: async (es: EcsSimplified[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
+          const client = await getAwsClient(ctx) as AWS;
           for (const e of es) {
             const simplifiedObjectMapped: SimplifiedObjectMapped = AwsEcsSimplifiedModule.utils.getSimplifiedObjectMapped(e);
             const service = await client.getServiceByName(simplifiedObjectMapped.cluster.clusterName, simplifiedObjectMapped.service.name);

--- a/src/modules/0.0.16/aws_ecs_simplified/index.ts
+++ b/src/modules/0.0.16/aws_ecs_simplified/index.ts
@@ -26,7 +26,6 @@ import { PublicRepository } from '../aws_ecr/entity'
 import cloudFns from './cloud_fns';
 import simplifiedMappers from './simplified_mappers';
 import { generateResourceName, processImageFromString } from './helpers';
-import { AwsAccount } from '../aws_account'
 
 export type SimplifiedObjectMapped = {
   securityGroup: SecurityGroup;
@@ -46,23 +45,11 @@ export type SimplifiedObjectMapped = {
 
 const prefix = 'iasql-ecs-';
 
-// TODO: remove this once the aws gateway gets disolved
-async function getAwsClient(ctx: Context): Promise<AWS> {
-  const awsCreds = await ctx?.orm?.findOne(AwsAccount.mappers.awsAccount.entity);
-  return new AWS({
-    region: awsCreds.region,
-    credentials: {
-      accessKeyId: awsCreds.accessKeyId,
-      secretAccessKey: awsCreds.secretAccessKey,
-    },
-  });
-}
-
 export const AwsEcsSimplifiedModule: Module2 = new Module2({
   ...metadata,
   utils: {
     ecsSimplifiedMapper: async (e: AwsService, ctx: Context) => {
-      const client = await getAwsClient(ctx) as AWS;
+      const client = await ctx.getAwsClient() as AWS;
       const out = new EcsSimplified();
       out.appName = e.serviceName?.substring(e.serviceName.indexOf(prefix) + prefix.length, e.serviceName.indexOf('-svc')) ?? '';
       out.desiredCount = e.desiredCount ?? 1;
@@ -86,7 +73,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
       try {
         // We use the service name as the appName
         const appName = service.serviceName?.substring(service.serviceName.indexOf(prefix) + prefix.length, service.serviceName.indexOf('-svc')) ?? '';
-        const client = await getAwsClient(ctx) as AWS;
+        const client = await ctx.getAwsClient() as AWS;
         // Check if the cluster follow the name pattern
         const cluster = await client.getCluster(service.clusterArn ?? '');
         if (!Object.is(cluster?.clusterName, generateResourceName(prefix, appName, 'Cluster'))) return false;
@@ -207,7 +194,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
       source: 'db',
       cloud: new Crud2({
         create: async (es: EcsSimplified[], ctx: Context) => {
-          const client = await getAwsClient(ctx) as AWS;
+          const client = await ctx.getAwsClient() as AWS;
           const defaultVpc = await AwsEcsSimplifiedModule.utils.cloud.get.defaultVpc(client);
           const defaultSubnets = await AwsEcsSimplifiedModule.utils.cloud.get.defaultSubnets(client, defaultVpc.VpcId);
           const out: any[] = [];
@@ -307,7 +294,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
           return out;
         },
         read: async (ctx: Context, id?: string) => {
-          const client = await getAwsClient(ctx) as AWS;
+          const client = await ctx.getAwsClient() as AWS;
           // read all clusters and find the ones that match our pattern
           const clusters = await client.getClusters();
           const relevantClusters = clusters?.filter(c => c.clusterName?.includes(prefix)) ?? [];
@@ -338,7 +325,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
           return 'update';
         },
         update: async (es: EcsSimplified[], ctx: Context) => {
-          const client = await getAwsClient(ctx) as AWS;
+          const client = await ctx.getAwsClient() as AWS;
           const out = [];
           for (const e of es) {
             const cloudRecord = ctx?.memo?.cloud?.EcsSimplified?.[e.appName ?? ''];
@@ -409,7 +396,7 @@ export const AwsEcsSimplifiedModule: Module2 = new Module2({
           return out;
         },
         delete: async (es: EcsSimplified[], ctx: Context) => {
-          const client = await getAwsClient(ctx) as AWS;
+          const client = await ctx.getAwsClient() as AWS;
           for (const e of es) {
             const simplifiedObjectMapped: SimplifiedObjectMapped = AwsEcsSimplifiedModule.utils.getSimplifiedObjectMapped(e);
             const service = await client.getServiceByName(simplifiedObjectMapped.cluster.clusterName, simplifiedObjectMapped.service.name);

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -372,3 +372,97 @@ export class Module2 {
     if (!def.provides.functions) this.provides.functions = functions;
   }
 }
+
+export class ModuleBase {
+  __dirname: string;
+  name: string;
+  version: string;
+  dependencies: string[];
+  provides: {
+    entities: { [key: string]: any, };
+    tables: string[];
+    functions: string[];
+    context?: Context;
+  };
+  context?: Context;
+  mappers: { [key: string]: Mapper2<any>, };
+  migrations: {
+    install: (q: QueryRunner) => Promise<void>;
+    remove: (q: QueryRunner) => Promise<void>;
+  };
+
+  constructor() {
+    if (!this.__dirname) throw new Error('Invalid Module defintion. No `__dirname` property found');
+    // Extract the name and version from `__dirname`
+    const pathSegments = this.__dirname.split(path.sep);
+    const name = pathSegments[pathSegments.length - 1];
+    const version = pathSegments[pathSegments.length - 2];
+    this.name = name;
+    this.version = version;
+    // Patch the dependencies list if not explicitly versioned
+    this.dependencies = this.dependencies.map(dep => dep.includes('@') ? dep : `${dep}@${this.version}`);
+    // Make sure every module depends on the `iasql_platform` module (except that module itself)
+    if (
+      this.name !== 'iasql_platform' &&
+      !this.dependencies.includes(`iasql_platform@${this.version}`)
+    ) throw new Error(`${this.name} did not declare an iasql_platform dependency and cannot be loaded.`);
+    const entityDir = `${this.__dirname}/entity`;
+    const entities = require(`${entityDir}/index`);
+    this.provides = {
+      entities,
+      tables: [], // These will be populated automatically below
+      functions: [], // TODO: Auto-populate these
+    }
+    if (this.context) this.provides.context = this.context;
+    this.mappers = Object.fromEntries(
+      Object.entries(this)
+        .filter(([_, m]: [string, any]) => m instanceof Mapper2) as [[string, Mapper2<any>]]
+    );
+    const migrationDir = `${this.__dirname}/migration`;
+    const files = fs.readdirSync(migrationDir).filter(f => !/.map$/.test(f));
+    if (files.length !== 1) throw new Error('Cannot determine which file is the migration');
+    const migration = require(`${migrationDir}/${files[0]}`);
+    // Assuming TypeORM migration files
+    const migrationClass = migration[Object.keys(migration)[0]];
+    if (!migrationClass || !migrationClass.prototype.up || !migrationClass.prototype.down) {
+      throw new Error('Presumed migration file is not a TypeORM migration');
+    }
+    this.migrations = {
+      install: migrationClass.prototype.up,
+      remove: migrationClass.prototype.down,
+    };
+    const syncified = new Function(
+      'return ' +
+      migrationClass.prototype.up
+        .toString()
+        .replace(/\basync\b/g, '')
+        .replace(/\bawait\b/g, '')
+        .replace(/^/, 'function')
+        // The following are only for the test suite, but need to be included at all times
+        .replace(/\/* istanbul ignore next *\//g, '')
+        .replace(/cov_.*/g, '')
+        // Drop any lines that don't have backticks because they must be handwritten add-ons
+        // to the migration file (TODO: Avoid this hackery somehow)
+        .split('\n')
+        .filter((l: string) => !/query\(/.test(l) || /`/.test(l))
+        .join('\n')
+    )();
+    const tables: string[] = [];
+    const functions: string[] = [];
+    syncified({ query: (text: string) => {
+      // TODO: Proper parsing (maybe LP?)
+      if (/^create table/i.test(text)) {
+        tables.push((text.match(/^[^"]*"([^"]*)"/) ?? [])[1]);
+      } else if (/^create or replace procedure/i.test(text)) {
+        functions.push((text.match(/^create or replace procedure ([^(]*)/i) ?? [])[0]);
+      } else if (/^create or replace function/i.test(text)) {
+        functions.push((text.match(/^create or replace function ([^(]*)/i) ?? [])[0]);
+      }
+      // Don't do anything for queries that don't match
+    }, });
+    this.provides.tables = tables;
+    this.provides.functions = functions;
+
+    return this;
+  }
+}

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -391,8 +391,8 @@ export class ModuleBase {
     remove: (q: QueryRunner) => Promise<void>;
   };
 
-  constructor() {
-    if (!this.dirname) throw new Error('Invalid Module defintion. No `__dirname` property found');
+  init() {
+    if (!this.dirname) throw new Error('Invalid Module defintion. No `dirname` property found');
     // Extract the name and version from `__dirname`
     const pathSegments = this.dirname.split(path.sep);
     const name = pathSegments[pathSegments.length - 1];
@@ -462,7 +462,5 @@ export class ModuleBase {
     }, });
     this.provides.tables = tables;
     this.provides.functions = functions;
-
-    return this;
   }
 }

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -374,7 +374,7 @@ export class Module2 {
 }
 
 export class ModuleBase {
-  __dirname: string;
+  dirname: string;
   name: string;
   version: string;
   dependencies: string[];
@@ -392,9 +392,9 @@ export class ModuleBase {
   };
 
   constructor() {
-    if (!this.__dirname) throw new Error('Invalid Module defintion. No `__dirname` property found');
+    if (!this.dirname) throw new Error('Invalid Module defintion. No `__dirname` property found');
     // Extract the name and version from `__dirname`
-    const pathSegments = this.__dirname.split(path.sep);
+    const pathSegments = this.dirname.split(path.sep);
     const name = pathSegments[pathSegments.length - 1];
     const version = pathSegments[pathSegments.length - 2];
     this.name = name;
@@ -406,7 +406,7 @@ export class ModuleBase {
       this.name !== 'iasql_platform' &&
       !this.dependencies.includes(`iasql_platform@${this.version}`)
     ) throw new Error(`${this.name} did not declare an iasql_platform dependency and cannot be loaded.`);
-    const entityDir = `${this.__dirname}/entity`;
+    const entityDir = `${this.dirname}/entity`;
     const entities = require(`${entityDir}/index`);
     this.provides = {
       entities,
@@ -418,7 +418,7 @@ export class ModuleBase {
       Object.entries(this)
         .filter(([_, m]: [string, any]) => m instanceof Mapper2) as [[string, Mapper2<any>]]
     );
-    const migrationDir = `${this.__dirname}/migration`;
+    const migrationDir = `${this.dirname}/migration`;
     const files = fs.readdirSync(migrationDir).filter(f => !/.map$/.test(f));
     if (files.length !== 1) throw new Error('Cannot determine which file is the migration');
     const migration = require(`${migrationDir}/${files[0]}`);


### PR DESCRIPTION
Part of #862 

The first step in switching to a class-based module system. Proposed new base class and implementation in the AwsAccount module. This conversion *should* work in a piecemeal basis as I made sure the new `ModuleBase` base class implements the `ModuleInterface` interface, but we'll let the test suite decide that. ;)

This is called "Part 1" not just because it's an incomplete conversion, but because there may be further changes/mutations to the pattern shown in this PR. The elimination of `utils` and `mappers` (sorta on the latter) flattens things and should improve Typescript's ability to infer type info, but if there are other [Mapper Footguns](https://github.com/iasql/docs/blob/bd7d9b7ac9af1fc4db3066131c56c61a1f8dd34b/docs/reference/apply_and_sync.md) that I can eliminate with module definition changes, then I hope to get them done this week, too.