### PR TITLE
Migrate the 'iasql_*' modules to the new class approach

### DIFF
--- a/src/modules/0.0.16/iasql_functions/index.ts
+++ b/src/modules/0.0.16/iasql_functions/index.ts
@@ -2,14 +2,11 @@
 
 import * as metadata from './module.json'
 import { IasqlOperationType, } from './entity'
-import { Module2, } from '../../interfaces'
+import { ModuleBase, } from '../../interfaces'
 
-export const IasqlFunctions: Module2 = new Module2({
-  ...metadata,
-  utils: {
-    // Since this is a special module, this is provided so the scheduler can always get the 'latest'
-    // operation types to check on. This also means that you can't drop old types willy-nilly
-    IasqlOperationType,
-  },
-  mappers: {},
-}, __dirname);
+class IasqlFunctions extends ModuleBase {
+  constructor() { super(); super.init(); }
+  dependencies = metadata.dependencies;
+  IasqlOperationType = IasqlOperationType;
+}
+export const iasqlFunctions = new IasqlFunctions();

--- a/src/modules/0.0.16/iasql_functions/index.ts
+++ b/src/modules/0.0.16/iasql_functions/index.ts
@@ -8,6 +8,6 @@ class IasqlFunctions extends ModuleBase {
   constructor() { super(); super.init(); }
   dirname = __dirname;
   dependencies = metadata.dependencies;
-  IasqlOperationType = IasqlOperationType;
+  iasqlOperationType = IasqlOperationType;
 }
 export const iasqlFunctions = new IasqlFunctions();

--- a/src/modules/0.0.16/iasql_functions/index.ts
+++ b/src/modules/0.0.16/iasql_functions/index.ts
@@ -6,6 +6,7 @@ import { ModuleBase, } from '../../interfaces'
 
 class IasqlFunctions extends ModuleBase {
   constructor() { super(); super.init(); }
+  dirname = __dirname;
   dependencies = metadata.dependencies;
   IasqlOperationType = IasqlOperationType;
 }

--- a/src/modules/0.0.16/iasql_platform/index.ts
+++ b/src/modules/0.0.16/iasql_platform/index.ts
@@ -8,7 +8,7 @@ class IasqlPlatform extends ModuleBase {
   constructor() { super(); super.init(); }
   dirname = __dirname;
   dependencies = metadata.dependencies;
-  IasqlModule = IasqlModule;
-  IasqlTables = IasqlTables;
+  iasqlModule = IasqlModule;
+  iasqlTables = IasqlTables;
 }
 export const iasqlPlatform = new IasqlPlatform();

--- a/src/modules/0.0.16/iasql_platform/index.ts
+++ b/src/modules/0.0.16/iasql_platform/index.ts
@@ -1,14 +1,14 @@
 /* THIS MODULE IS A SPECIAL SNOWFLAKE. DON'T LOOK AT IT FOR HOW TO WRITE A REAL MODULE */
 
-import { Module2, } from '../../interfaces'
+import { ModuleBase, } from '../../interfaces'
 import * as metadata from './module.json'
 import { IasqlModule, IasqlTables, } from './entity'
 
-export const IasqlPlatform: Module2 = new Module2({
-  ...metadata,
-  utils: {
-    IasqlModule,
-    IasqlTables,
-  },
-  mappers: {},
-}, __dirname);
+class IasqlPlatform extends ModuleBase {
+  constructor() { super(); super.init(); }
+  dirname = __dirname;
+  dependencies = metadata.dependencies;
+  IasqlModule = IasqlModule;
+  IasqlTables = IasqlTables;
+}
+export const iasqlPlatform = new IasqlPlatform();

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -369,7 +369,7 @@ export async function apply(dbId: string, dryRun: boolean, ormOpt?: TypeormWrapp
   try {
     orm = !ormOpt ? await TypeormWrapper.createConn(dbId) : ormOpt;
     // Find all of the installed modules, and create the context object only for these
-    const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.IasqlModule ?? throwError('Core IasqlModule not found');
+    const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.iasqlModule ?? throwError('Core IasqlModule not found');
     const moduleNames = (await orm.find(iasqlModule)).map((m: any) => m.name);
     const memo: any = {}; // TODO: Stronger typing here
     const context: Context = { orm, memo, }; // Every module gets access to the DB
@@ -588,7 +588,7 @@ export async function sync(dbId: string, dryRun: boolean, ormOpt?: TypeormWrappe
   try {
     orm = !ormOpt ? await TypeormWrapper.createConn(dbId) : ormOpt;
     // Find all of the installed modules, and create the context object only for these
-    const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.IasqlModule ?? throwError('Core IasqlModule not found');
+    const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.iasqlModule ?? throwError('Core IasqlModule not found');
     const moduleNames = (await orm.find(iasqlModule)).map((m: any) => m.name);
     const memo: any = {}; // TODO: Stronger typing here
     const context: Context = { orm, memo, }; // Every module gets access to the DB
@@ -803,8 +803,8 @@ export async function modules(all: boolean, installed: boolean, dbId: string) {
   if (all) {
     return JSON.stringify(allModules);
   } else if (installed && dbId) {
-    const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.IasqlModule ?? throwError('Core IasqlModule not found');
-    const iasqlTables = Modules?.IasqlPlatform?.utils?.IasqlTables ?? Modules?.iasqlPlatform?.IasqlTables ?? throwError('Core IasqlTables not found');
+    const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.iasqlModule ?? throwError('Core IasqlModule not found');
+    const iasqlTables = Modules?.IasqlPlatform?.utils?.IasqlTables ?? Modules?.iasqlPlatform?.iasqlTables ?? throwError('Core IasqlTables not found');
     const entities: Function[] = [ iasqlModule, iasqlTables, ];
     const orm = await TypeormWrapper.createConn(dbId, { entities } as PostgresConnectionOptions);
     const mods = await orm.find(iasqlModule);
@@ -851,7 +851,7 @@ export async function install(moduleList: string[], dbId: string, dbUser: string
   const queryRunner = orm.createQueryRunner();
   await queryRunner.connect();
   // See what modules are already installed and prune them from the list
-  const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.IasqlModule ?? throwError('Core IasqlModule not found');
+  const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.iasqlModule ?? throwError('Core IasqlModule not found');
   const existingModules = (await orm.find(iasqlModule)).map((m: any) => m.name);
   for (let i = 0; i < mods.length; i++) {
     if (existingModules.includes(`${mods[i].name}@${mods[i].version}`)) {
@@ -935,7 +935,7 @@ ${Object.keys(tableCollisions)
       );
       await orm.save(iasqlModule, e);
 
-      const iasqlTables = Modules?.IasqlPlatform?.utils?.IasqlTables ?? Modules?.iasqlPlatform?.IasqlTables ?? throwError('Core IasqlModule not found');
+      const iasqlTables = Modules?.IasqlPlatform?.utils?.IasqlTables ?? Modules?.iasqlPlatform?.iasqlTables ?? throwError('Core IasqlModule not found');
       const modTables = md?.provides?.tables?.map((t) => {
         const mt = new iasqlTables();
         mt.table = t;
@@ -1024,8 +1024,8 @@ export async function uninstall(moduleList: string[], dbId: string, orm?: Typeor
   const queryRunner = orm.createQueryRunner();
   await queryRunner.connect();
   // See what modules are already uninstalled and prune them from the list
-  const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.IasqlModule ?? throwError('Core IasqlModule not found');
-  const iasqlTables = Modules?.IasqlPlatform?.utils?.IasqlTables ?? Modules?.iasqlPlatform?.IasqlTables ?? throwError('Core IasqlTables not found');
+  const iasqlModule = Modules?.IasqlPlatform?.utils?.IasqlModule ?? Modules?.iasqlPlatform?.iasqlModule ?? throwError('Core IasqlModule not found');
+  const iasqlTables = Modules?.IasqlPlatform?.utils?.IasqlTables ?? Modules?.iasqlPlatform?.iasqlTables ?? throwError('Core IasqlTables not found');
   const existingModules = (await orm.find(iasqlModule)).map((m: any) => m.name);
   for (let i = 0; i < mods.length; i++) {
     if (!existingModules.includes(`${mods[i].name}@${mods[i].version}`)) {

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -14,7 +14,7 @@ import { throwError, } from '../config/config'
 
 const latest = modules[config.modules.latestVersion];
 
-const { IasqlOperationType, } = latest?.IasqlFunctions?.utils ?? latest?.iasqlFunctions ?? throwError('Core IasqlFunctions not found');
+const IasqlOperationType = latest?.IasqlFunctions?.utils?.IasqlOperationType ?? latest?.iasqlFunctions?.iasqlOperationType ?? throwError('Core IasqlFunctions not found');
 
 const workerRunners: { [key: string]: { runner: any, conn: any}, } = {}; // TODO: What is the runner type?
 

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -10,10 +10,11 @@ import logger, { logErrSentry } from './logger'
 import { TypeormWrapper } from './typeorm'
 import { IasqlDatabase } from '../entity'
 import config from '../config'
+import { throwError, } from '../config/config'
 
 const latest = modules[config.modules.latestVersion];
 
-const { IasqlOperationType, } = latest.IasqlFunctions.utils;
+const { IasqlOperationType, } = latest?.IasqlFunctions?.utils ?? latest?.iasqlFunctions ?? throwError('Core IasqlFunctions not found');
 
 const workerRunners: { [key: string]: { runner: any, conn: any}, } = {}; // TODO: What is the runner type?
 

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -10,7 +10,7 @@ const latest = modules[config.modules.latestVersion];
 
 // Weird little dance to make it a type again.
 // From: https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums
-const { IasqlOperationType, } = latest?.IasqlFunctions?.utils ?? latest?.iasqlFunctions ?? throwError('Core IasqlFunctions not found');
+const IasqlOperationType = latest?.IasqlFunctions?.utils?.IasqlOperationType ?? latest?.iasqlFunctions.iasqlOperationType ?? throwError('Core IasqlFunctions not found');
 type IasqlOperationType = typeof IasqlOperationType[keyof typeof IasqlOperationType];
 
 const singleton = config.telemetry ? Amplitude.init(config.telemetry.amplitudeKey) : undefined;

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -2,6 +2,7 @@ import * as Amplitude from '@amplitude/node'
 import * as sentry from '@sentry/node'
 
 import config, { IASQL_ENV } from '../config'
+import { throwError, } from '../config/config'
 import logger from './logger'
 import { modules, } from '../modules'
 
@@ -9,7 +10,7 @@ const latest = modules[config.modules.latestVersion];
 
 // Weird little dance to make it a type again.
 // From: https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums
-const { IasqlOperationType, } = latest.IasqlFunctions.utils;
+const { IasqlOperationType, } = latest?.IasqlFunctions?.utils ?? latest?.iasqlFunctions ?? throwError('Core IasqlFunctions not found');
 type IasqlOperationType = typeof IasqlOperationType[keyof typeof IasqlOperationType];
 
 const singleton = config.telemetry ? Amplitude.init(config.telemetry.amplitudeKey) : undefined;


### PR DESCRIPTION
These modules are special versus the rest of them as they are manipulated directly by various `src/services` files, and mostly act as the foundational layer for the useful IaSQL modules, so I converted them in a separate PR to keep this somewhat contained.

Lots of conditional logic in the `src/services` files added that can be removed when this version is the oldest supported version.