### PR TITLE
Convert 'aws_vpc' to the new class approach

### DIFF
--- a/src/modules/0.0.16/aws_ec2/index.ts
+++ b/src/modules/0.0.16/aws_ec2/index.ts
@@ -14,7 +14,7 @@ import { Context, Crud2, Mapper2, Module2, } from '../../interfaces'
 import * as metadata from './module.json'
 import { AwsElbModule } from '../aws_elb'
 import { AwsIamModule } from '../aws_iam'
-import { AwsVpcModule } from '../aws_vpc'
+import { awsVpcModule } from '../aws_vpc'
 import {
   AWS,
   attachVolume,
@@ -80,8 +80,8 @@ export const AwsEc2Module: Module2 = new Module2({
           }
         } catch (_) { /** Do nothing */ }
       }
-      out.subnet = await AwsVpcModule.mappers.subnet.db.read(ctx, instance.SubnetId) ??
-        await AwsVpcModule.mappers.subnet.cloud.read(ctx, instance.SubnetId);
+      out.subnet = await awsVpcModule.subnet.db.read(ctx, instance.SubnetId) ??
+        await awsVpcModule.subnet.cloud.read(ctx, instance.SubnetId);
       out.hibernationEnabled = instance.HibernationOptions?.Configured ?? false;
       return out;
     },
@@ -111,8 +111,8 @@ export const AwsEc2Module: Module2 = new Module2({
       if (!vol?.VolumeId) return undefined;
       out.volumeId = vol.VolumeId;
       out.volumeType = vol.VolumeType as GeneralPurposeVolumeType;
-      out.availabilityZone = await AwsVpcModule.mappers.availabilityZone.db.read(ctx, vol.AvailabilityZone) ??
-        await AwsVpcModule.mappers.availabilityZone.cloud.read(ctx, vol.AvailabilityZone);
+      out.availabilityZone = await awsVpcModule.availabilityZone.db.read(ctx, vol.AvailabilityZone) ??
+        await awsVpcModule.availabilityZone.cloud.read(ctx, vol.AvailabilityZone);
       out.size = vol.Size ?? 1;
       out.iops = vol.Iops;
       out.throughput = vol.Throughput;

--- a/src/modules/0.0.16/aws_ecs_fargate/index.ts
+++ b/src/modules/0.0.16/aws_ecs_fargate/index.ts
@@ -36,7 +36,7 @@ import {
   AwsIamModule,
   AwsSecurityGroupModule,
   AwsCloudwatchModule,
-  AwsVpcModule,
+  awsVpcModule,
 } from '..'
 import * as metadata from './module.json'
 import logger from '../../../services/logger'
@@ -476,8 +476,8 @@ export const AwsEcsFargateModule: Module2 = new Module2({
           // Even though we already have the subnet ids, we look for them to avoid having misconfigured resources
           let subnet: Subnet;
           try {
-            subnet = await AwsVpcModule.mappers.subnet.db.read(ctx, sn) ??
-              await AwsVpcModule.mappers.subnet.cloud.read(ctx, sn);
+            subnet = await awsVpcModule.subnet.db.read(ctx, sn) ??
+              await awsVpcModule.subnet.cloud.read(ctx, sn);
             if (!subnet) return undefined;
           } catch (e: any) {
             if (e.Code === 'InvalidSubnetID.NotFound') return undefined;

--- a/src/modules/0.0.16/aws_elb/index.ts
+++ b/src/modules/0.0.16/aws_elb/index.ts
@@ -34,7 +34,7 @@ import {
   TargetGroupIpAddressTypeEnum,
   TargetTypeEnum,
 } from './entity'
-import { AwsVpcModule, } from '../aws_vpc'
+import { awsVpcModule, } from '../aws_vpc'
 import { Context, Crud2, Mapper2, Module2, } from '../../interfaces'
 import { AwsAcmListModule, AwsSecurityGroupModule } from '..'
 import * as metadata from './module.json'
@@ -289,8 +289,8 @@ export const AwsElbModule: Module2 = new Module2({
       out.securityGroups = securityGroups.filter(sg => !!sg);
       out.ipAddressType = lb.IpAddressType as IpAddressType;
       out.customerOwnedIpv4Pool = lb.CustomerOwnedIpv4Pool;
-      const vpc = await AwsVpcModule.mappers.vpc.db.read(ctx, lb.VpcId) ??
-        await AwsVpcModule.mappers.vpc.cloud.read(ctx, lb.VpcId);
+      const vpc = await awsVpcModule.vpc.db.read(ctx, lb.VpcId) ??
+        await awsVpcModule.vpc.cloud.read(ctx, lb.VpcId);
       out.vpc = vpc;
       out.availabilityZones = lb.AvailabilityZones?.map(az => az.ZoneName ?? '') ?? [];
       out.subnets = lb.AvailabilityZones?.map(az => az.SubnetId ?? '') ?? [];
@@ -315,8 +315,8 @@ export const AwsElbModule: Module2 = new Module2({
       out.healthCheckPath = tg.HealthCheckPath;
       out.protocolVersion = tg.ProtocolVersion as ProtocolVersionEnum;
       try {
-        const vpc = await AwsVpcModule.mappers.vpc.db.read(ctx, tg.VpcId) ??
-          await AwsVpcModule.mappers.vpc.cloud.read(ctx, tg.VpcId);
+        const vpc = await awsVpcModule.vpc.db.read(ctx, tg.VpcId) ??
+          await awsVpcModule.vpc.cloud.read(ctx, tg.VpcId);
         if (tg.VpcId && !vpc) return undefined;
         out.vpc = vpc;
       } catch (e: any) {

--- a/src/modules/0.0.16/aws_rds/index.ts
+++ b/src/modules/0.0.16/aws_rds/index.ts
@@ -17,7 +17,7 @@ import { createWaiter, WaiterState } from '@aws-sdk/util-waiter'
 import { AWS, crudBuilder2, crudBuilderFormat, paginateBuilder, mapLin, } from '../../../services/aws_macros'
 import { ParameterGroup, ParameterGroupFamily, RDS, } from './entity'
 import { Context, Crud2, Mapper2, Module2, } from '../../interfaces'
-import { AwsSecurityGroupModule, AwsVpcModule, } from '..'
+import { AwsSecurityGroupModule, awsVpcModule, } from '..'
 import * as metadata from './module.json'
 
 interface DBParameterGroupWParameters extends DBParameterGroup {
@@ -203,7 +203,7 @@ export const AwsRdsModule: Module2 = new Module2({
     rdsMapper: async (rds: any, ctx: Context) => {
       const out = new RDS();
       out.allocatedStorage = rds?.AllocatedStorage;
-      out.availabilityZone = await AwsVpcModule.mappers.availabilityZone.db.read(
+      out.availabilityZone = await awsVpcModule.availabilityZone.db.read(
         ctx,
         rds?.AvailabilityZone
       );

--- a/src/modules/0.0.16/aws_security_group/index.ts
+++ b/src/modules/0.0.16/aws_security_group/index.ts
@@ -21,7 +21,7 @@ import {
 import { SecurityGroup, SecurityGroupRule, } from './entity'
 import { Context, Crud2, Mapper2, Module2, } from '../../interfaces'
 import * as metadata from './module.json'
-import { AwsVpcModule } from '../aws_vpc'
+import { awsVpcModule } from '../aws_vpc'
 import { Vpc } from '../aws_vpc/entity'
 import logger from '../../../services/logger'
 
@@ -110,8 +110,8 @@ export const AwsSecurityGroupModule: Module2 = new Module2({
       out.ownerId = sg.OwnerId;
       out.groupId = sg.GroupId;
       if (sg.VpcId) {
-        out.vpc = await AwsVpcModule.mappers.vpc.db.read(ctx, sg.VpcId) ??
-          await AwsVpcModule.mappers.vpc.cloud.read(ctx, sg.VpcId);
+        out.vpc = await awsVpcModule.vpc.db.read(ctx, sg.VpcId) ??
+          await awsVpcModule.vpc.cloud.read(ctx, sg.VpcId);
         if (!out.vpc) throw new Error(`Waiting for VPC ${sg.VpcId}`);
       };
       return out;
@@ -160,7 +160,7 @@ export const AwsSecurityGroupModule: Module2 = new Module2({
           continue;
         }
         if (!e.vpc) {
-          const vpcs: Vpc[] = await AwsVpcModule.mappers.vpc.cloud.read(ctx);
+          const vpcs: Vpc[] = await awsVpcModule.vpc.cloud.read(ctx);
           if (!vpcs.length) {
             throw new Error('Vpcs need to be loaded first');
           }
@@ -215,11 +215,11 @@ export const AwsSecurityGroupModule: Module2 = new Module2({
             if (out.vpc && out.vpc.vpcId && !out.vpc.id) {
               // There may be a race condition/double write happening here, so check if this thing
               // has been created in the meantime
-              const dbVpc = await AwsVpcModule.mappers.vpc.db.read(ctx, out.vpc.vpcId);
+              const dbVpc = await awsVpcModule.vpc.db.read(ctx, out.vpc.vpcId);
               if (!!dbVpc) {
                 out.vpc = dbVpc;
               } else {
-                await AwsVpcModule.mappers.vpc.db.create(out.vpc, ctx);
+                await awsVpcModule.vpc.db.create(out.vpc, ctx);
               }
             }
           }
@@ -237,7 +237,7 @@ export const AwsSecurityGroupModule: Module2 = new Module2({
           const securityGroups = await ctx.orm.find(SecurityGroup, opts);
           for (const sg of securityGroups) {
             if (!sg.vpc) {
-              const vpcs: Vpc[] = await AwsVpcModule.mappers.vpc.db.read(ctx);
+              const vpcs: Vpc[] = await awsVpcModule.vpc.db.read(ctx);
               if (!vpcs.length) {
                 throw new Error('Vpcs need to be loaded first');
               }
@@ -258,11 +258,11 @@ export const AwsSecurityGroupModule: Module2 = new Module2({
             if (out.vpc && out.vpc.vpcId && !out.vpc.id) {
               // There may be a race condition/double write happening here, so check if this thing
               // has been created in the meantime
-              const dbVpc = await AwsVpcModule.mappers.vpc.db.read(ctx, out.vpc.vpcId);
+              const dbVpc = await awsVpcModule.vpc.db.read(ctx, out.vpc.vpcId);
               if (!!dbVpc) {
                 out.vpc = dbVpc;
               } else {
-                await AwsVpcModule.mappers.vpc.db.create(out.vpc, ctx);
+                await awsVpcModule.vpc.db.create(out.vpc, ctx);
               }
             }
           }

--- a/src/modules/0.0.16/aws_vpc/index.ts
+++ b/src/modules/0.0.16/aws_vpc/index.ts
@@ -2,13 +2,14 @@ import {
   Address,
   AllocateAddressCommandInput,
   CreateNatGatewayCommandInput,
+  CreateVpcCommandInput,
   CreateVpcEndpointCommandInput,
   DescribeNatGatewaysCommandInput,
+  DescribeVpcsCommandInput,
   EC2,
   ModifyVpcEndpointCommandInput,
   NatGateway as AwsNatGateway,
   NatGatewayState as AwsNatGatewayState,
-  VpcState as AwsVpcState,
   RouteTable,
   Subnet as AwsSubnet,
   Tag,
@@ -19,8 +20,6 @@ import {
   paginateDescribeSubnets,
   paginateDescribeVpcEndpoints,
   paginateDescribeVpcs,
-  CreateVpcCommandInput,
-  DescribeVpcsCommandInput,
 } from '@aws-sdk/client-ec2'
 import { createWaiter, WaiterState } from '@aws-sdk/util-waiter'
 
@@ -43,7 +42,7 @@ import {
   Vpc,
   VpcState,
 } from './entity'
-import { Context, Crud2, Mapper2, Module2, } from '../../interfaces'
+import { Context, Crud2, Mapper2, ModuleBase, } from '../../interfaces'
 import * as metadata from './module.json'
 import isEqual from 'lodash.isequal'
 
@@ -322,629 +321,676 @@ async function createElasticIp(client: EC2, tags?: { [key: string] : string }) {
   return await client.allocateAddress(allocateAddressCommandInput);
 }
 
-export const AwsVpcModule: Module2 = new Module2({
-  ...metadata,
-  utils: {
-    subnetMapper: async (sn: AwsSubnet, ctx: Context) => {
-      const out = new Subnet();
-      if (!sn?.SubnetId || !sn?.VpcId) return undefined;
-      out.state = sn.State as SubnetState;
-      if (!sn.AvailabilityZone) return undefined;
-      out.availabilityZone = await AwsVpcModule.mappers.availabilityZone.db.read(ctx, sn.AvailabilityZone) ??
-        await AwsVpcModule.mappers.availabilityZone.cloud.read(ctx, sn.AvailabilityZone);
-      out.vpc = await AwsVpcModule.mappers.vpc.db.read(ctx, sn.VpcId) ??
-        await AwsVpcModule.mappers.vpc.cloud.read(ctx, sn.VpcId);
-      if (sn.VpcId && !out.vpc) throw new Error(`Waiting for VPC ${sn.VpcId}`);
-      if (out.vpc && out.vpc.vpcId && !out.vpc.id) {
-        await AwsVpcModule.mappers.vpc.db.create(out.vpc, ctx);
+class AwsVpcModule extends ModuleBase {
+  constructor() { super(); super.init(); }
+  dependencies = metadata.dependencies;
+
+  async subnetMapper(sn: AwsSubnet, ctx: Context) {
+    const out = new Subnet();
+    if (!sn?.SubnetId || !sn?.VpcId) return undefined;
+    out.state = sn.State as SubnetState;
+    if (!sn.AvailabilityZone) return undefined;
+    out.availabilityZone = await this.availabilityZone.db.read(ctx, sn.AvailabilityZone) ??
+      await this.availabilityZone.cloud.read(ctx, sn.AvailabilityZone);
+    out.vpc = await this.vpc.db.read(ctx, sn.VpcId) ??
+      await this.vpc.cloud.read(ctx, sn.VpcId);
+    if (sn.VpcId && !out.vpc) throw new Error(`Waiting for VPC ${sn.VpcId}`);
+    if (out.vpc && out.vpc.vpcId && !out.vpc.id) {
+      await this.vpc.db.create(out.vpc, ctx);
+    }
+    out.availableIpAddressCount = sn.AvailableIpAddressCount;
+    out.cidrBlock = sn.CidrBlock;
+    out.subnetId = sn.SubnetId;
+    out.ownerId = sn.OwnerId;
+    out.subnetArn = sn.SubnetArn;
+    return out;
+  }
+
+  vpcMapper(vpc: AwsVpc) {
+    const out = new Vpc();
+    if (!vpc?.VpcId || !vpc?.CidrBlock) return undefined;
+    out.vpcId = vpc.VpcId;
+    out.cidrBlock = vpc.CidrBlock;
+    out.state = vpc.State as VpcState;
+    out.isDefault = vpc.IsDefault ?? false;
+    const tags: { [key: string]: any } = {};
+    (vpc.Tags || []).filter(t => t.hasOwnProperty('Key') && t.hasOwnProperty('Value')).forEach(t => {
+      tags[t.Key as string] = t.Value;
+    });
+    out.tags = tags;
+
+    return out;
+  }
+
+  async natGatewayMapper(nat: AwsNatGateway, ctx: Context) {
+    const out = new NatGateway();
+    out.connectivityType = nat.ConnectivityType as ConnectivityType;
+    const natPublicAddress = nat.NatGatewayAddresses?.filter(n => !!n.AllocationId).pop();
+    if (natPublicAddress?.AllocationId) {
+      try {
+        out.elasticIp = await this.elasticIp.db.read(ctx, natPublicAddress.AllocationId) ??
+          await this.elasticIp.cloud.read(ctx, natPublicAddress.AllocationId);
+      } catch (error: any) {
+        if (error.Code === 'InvalidAllocationID.NotFound') return undefined;
       }
-      out.availableIpAddressCount = sn.AvailableIpAddressCount;
-      out.cidrBlock = sn.CidrBlock;
-      out.subnetId = sn.SubnetId;
-      out.ownerId = sn.OwnerId;
-      out.subnetArn = sn.SubnetArn;
-      return out;
-    },
-    vpcMapper: (vpc: AwsVpc) => {
-      const out = new Vpc();
-      if (!vpc?.VpcId || !vpc?.CidrBlock) return undefined;
-      out.vpcId = vpc.VpcId;
-      out.cidrBlock = vpc.CidrBlock;
-      out.state = vpc.State as VpcState;
-      out.isDefault = vpc.IsDefault ?? false;
-      const tags: { [key: string]: any } = {};
-      (vpc.Tags || []).filter(t => t.hasOwnProperty('Key') && t.hasOwnProperty('Value')).forEach(t => {
-        tags[t.Key as string] = t.Value;
+      if (!out.elasticIp) throw new Error('Not valid elastic ip, yet?');
+    }
+    out.natGatewayId = nat.NatGatewayId;
+    out.state = nat.State as NatGatewayState;
+    out.subnet = await this.subnet.db.read(ctx, nat.SubnetId) ??
+      await this.subnet.cloud.read(ctx, nat.SubnetId);
+    if (nat.SubnetId && !out.subnet) return undefined;
+    const tags: { [key: string]: string } = {};
+    (nat.Tags || []).filter(t => !!t.Key && !!t.Value).forEach(t => {
+      tags[t.Key as string] = t.Value as string;
+    });
+    out.tags = tags;
+    return out;
+  }
+
+  elasticIpMapper(eip: any) { // TODO: Fix this input type
+    const out = new ElasticIp();
+    out.allocationId = eip.AllocationId;
+    if (!out.allocationId) return undefined;
+    out.publicIp = eip.PublicIp;
+    const tags: { [key: string]: string } = {};
+    (eip.Tags || []).filter((t: any) => !!t.Key && !!t.Value).forEach((t: any) => {
+      tags[t.Key as string] = t.Value as string;
+    });
+    out.tags = tags;
+    return out;
+  }
+
+  async endpointGatewayMapper(eg: AwsVpcEndpoint, ctx: Context) {
+    const out = new EndpointGateway();
+    out.vpcEndpointId = eg.VpcEndpointId;
+    if (!out.vpcEndpointId) return undefined;
+    if (!eg.ServiceName) return undefined;
+    const service = this.getServiceFromServiceName(eg.ServiceName);
+    if (!service) return undefined;
+    out.service = service;
+    if (!out.service) return undefined;
+    out.vpc = await this.vpc.db.read(ctx, eg.VpcId) ??
+      await this.vpc.cloud.read(ctx, eg.VpcId);
+    if (!out.vpc) return undefined;
+    out.policyDocument = eg.PolicyDocument;
+    out.state = eg.State;
+    out.routeTableIds = eg.RouteTableIds;
+    if (eg.Tags?.length) {
+      const tags: { [key: string]: string } = {};
+      eg.Tags.filter((t: any) => !!t.Key && !!t.Value).forEach((t: any) => {
+        tags[t.Key as string] = t.Value as string;
       });
       out.tags = tags;
+    }
+    return out;
+  }
 
-      return out;
-    },
-    natGatewayMapper: async (nat: AwsNatGateway, ctx: Context) => {
-      const out = new NatGateway();
-      out.connectivityType = nat.ConnectivityType as ConnectivityType;
-      const natPublicAddress = nat.NatGatewayAddresses?.filter(n => !!n.AllocationId).pop();
-      if (natPublicAddress?.AllocationId) {
-        try {
-          out.elasticIp = await AwsVpcModule.mappers.elasticIp.db.read(ctx, natPublicAddress.AllocationId) ??
-            await AwsVpcModule.mappers.elasticIp.cloud.read(ctx, natPublicAddress.AllocationId);
-        } catch (error: any) {
-          if (error.Code === 'InvalidAllocationID.NotFound') return undefined;
+  getServiceFromServiceName(serviceName: string) {
+    if (serviceName.includes('s3')) return EndpointGatewayService.S3;
+    if (serviceName.includes('dynamodb')) return EndpointGatewayService.DYNAMODB;
+  }
+
+  eqTags(a?: { [key: string]: string }, b?: { [key: string]: string }) {
+    return isEqual(a, b);
+  }
+
+  subnet: Mapper2<Subnet> = new Mapper2<Subnet>({
+    entity: Subnet,
+    equals: (a: Subnet, b: Subnet) => Object.is(a.subnetId, b.subnetId) &&
+      Object.is(a?.availabilityZone?.name, b?.availabilityZone?.name), // TODO: Do better
+    source: 'db',
+    cloud: new Crud2({
+      create: async (es: Subnet[], ctx: Context) => {
+        // TODO: Add support for creating default subnets (only one is allowed, also add
+        // constraint that a single subnet is set as default)
+        const client = await ctx.getAwsClient() as AWS;
+        for (const e of es) {
+          const input: any = {
+            AvailabilityZone: e.availabilityZone.name,
+            VpcId: e.vpc.vpcId,
+          };
+          if (e.cidrBlock) input.CidrBlock = e.cidrBlock;
+          const res = await createSubnet(client.ec2client, input);
+          if (res?.Subnet) {
+            // TODO: How to not require it to be a singleton here?
+            const newSubnet = await awsVpcModule.subnetMapper(res.Subnet, ctx);
+            if (!newSubnet) continue;
+            newSubnet.id = e.id;
+            Object.keys(newSubnet).forEach(k => (e as any)[k] = (newSubnet as any)[k]);
+            await awsVpcModule.subnet.db.update(e, ctx);
+            // TODO: What to do if no subnet returned?
+          }
         }
-        if (!out.elasticIp) throw new Error('Not valid elastic ip, yet?');
-      }
-      out.natGatewayId = nat.NatGatewayId;
-      out.state = nat.State as NatGatewayState;
-      out.subnet = await AwsVpcModule.mappers.subnet.db.read(ctx, nat.SubnetId) ??
-        await AwsVpcModule.mappers.subnet.cloud.read(ctx, nat.SubnetId);
-      if (nat.SubnetId && !out.subnet) return undefined;
-      const tags: { [key: string]: string } = {};
-      (nat.Tags || []).filter(t => !!t.Key && !!t.Value).forEach(t => {
-        tags[t.Key as string] = t.Value as string;
-      });
-      out.tags = tags;
-      return out;
-    },
-    elasticIpMapper: (eip: any) => {
-      const out = new ElasticIp();
-      out.allocationId = eip.AllocationId;
-      if (!out.allocationId) return undefined;
-      out.publicIp = eip.PublicIp;
-      const tags: { [key: string]: string } = {};
-      (eip.Tags || []).filter((t: any) => !!t.Key && !!t.Value).forEach((t: any) => {
-        tags[t.Key as string] = t.Value as string;
-      });
-      out.tags = tags;
-      return out;
-    },
-    endpointGatewayMapper: async (eg: AwsVpcEndpoint, ctx: Context) => {
-      const out = new EndpointGateway();
-      out.vpcEndpointId = eg.VpcEndpointId;
-      if (!out.vpcEndpointId) return undefined;
-      out.service = AwsVpcModule.utils.getServiceFromServiceName(eg.ServiceName);
-      if (!out.service) return undefined;
-      out.vpc = await AwsVpcModule.mappers.vpc.db.read(ctx, eg.VpcId) ??
-        await AwsVpcModule.mappers.vpc.cloud.read(ctx, eg.VpcId);
-      if (!out.vpc) return undefined;
-      out.policyDocument = eg.PolicyDocument;
-      out.state = eg.State;
-      out.routeTableIds = eg.RouteTableIds;
-      if (eg.Tags?.length) {
-        const tags: { [key: string]: string } = {};
-        eg.Tags.filter((t: any) => !!t.Key && !!t.Value).forEach((t: any) => {
-          tags[t.Key as string] = t.Value as string;
-        });
-        out.tags = tags;
-      }
-      return out;
-    },
-    getServiceFromServiceName: (serviceName: string) => {
-      if (serviceName.includes('s3')) return EndpointGatewayService.S3;
-      if (serviceName.includes('dynamodb')) return EndpointGatewayService.DYNAMODB;
-    },
-    eqTags: (a: { [key: string]: string }, b: { [key: string]: string }) => {
-      return isEqual(a, b);
-    },
-  },
-  mappers: {
-    subnet: new Mapper2<Subnet>({
-      entity: Subnet,
-      equals: (a: Subnet, b: Subnet) => Object.is(a.subnetId, b.subnetId) &&
-        Object.is(a?.availabilityZone?.name, b?.availabilityZone?.name), // TODO: Do better
-      source: 'db',
-      cloud: new Crud2({
-        create: async (es: Subnet[], ctx: Context) => {
-          // TODO: Add support for creating default subnets (only one is allowed, also add
-          // constraint that a single subnet is set as default)
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            const input: any = {
-              AvailabilityZone: e.availabilityZone.name,
-              VpcId: e.vpc.vpcId,
-            };
-            if (e.cidrBlock) input.CidrBlock = e.cidrBlock;
-            const res = await createSubnet(client.ec2client, input);
-            if (res?.Subnet) {
-              const newSubnet = await AwsVpcModule.utils.subnetMapper(res.Subnet, ctx);
-              newSubnet.id = e.id;
-              Object.keys(newSubnet).forEach(k => (e as any)[k] = newSubnet[k]);
-              await AwsVpcModule.mappers.subnet.db.update(e, ctx);
-              // TODO: What to do if no subnet returned?
-            }
-          }
-        },
-        read: async (ctx: Context, id?: string) => {
-          const client = await ctx.getAwsClient() as AWS;
-          // TODO: Convert AWS subnet representation to our own
-          if (!!id) {
-            const rawSubnet = await getSubnet(client.ec2client, id);
-            if (!rawSubnet) return;
-            return await AwsVpcModule.utils.subnetMapper(rawSubnet, ctx);
-          } else {
-            const out = [];
-            for (const sn of await getSubnets(client.ec2client)) {
-              out.push(await AwsVpcModule.utils.subnetMapper(sn, ctx));
-            }
-            return out;
-          }
-        },
-        update: async (es: Subnet[], ctx: Context) => {
-          // There is no update mechanism for a subnet so instead we will create a new one and the
-          // next loop through should delete the old one
-          return await AwsVpcModule.mappers.subnet.cloud.create(es, ctx);
-        },
-        delete: async (es: Subnet[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            // Special behavior here. You're not allowed to mess with the "default" VPC or its subnets.
-            // Any attempt to update it is instead turned into *restoring* the value in
-            // the database to match the cloud value
-            if (e.vpc?.isDefault) {
-              // For delete, we have un-memoed the record, but the record passed in *is* the one
-              // we're interested in, which makes it a bit simpler here
-              const vpc = ctx?.memo?.db?.Vpc[e.vpc.vpcId ?? ''] ?? null;
-              e.vpc.id = vpc.id;
-              await AwsVpcModule.mappers.subnet.db.update(e, ctx);
-              // Make absolutely sure it shows up in the memo
-              ctx.memo.db.Subnet[e.subnetId ?? ''] = e;
-            } else {
-              await deleteSubnet(client.ec2client, {
-                SubnetId: e.subnetId,
-              });
-            }
-          }
-        },
-      }),
-    }),
-    vpc: new Mapper2<Vpc>({
-      entity: Vpc,
-      equals: (a: Vpc, b: Vpc) => {
-        const result = Object.is(a.cidrBlock, b.cidrBlock) && Object.is(a.state, b.state) && Object.is(a.isDefault, b.isDefault) &&
-          (AwsVpcModule.utils.eqTags(a.tags, b.tags));
-        return result;
       },
-      source: 'db',
-      cloud: new Crud2({
-        updateOrReplace: (a: Vpc, b: Vpc) => {
-          if (!Object.is(a.cidrBlock, b.cidrBlock) || !Object.is(a.isDefault, b.isDefault)) return "replace";
-          else return "update";
-        },
-        create: async (es: Vpc[], ctx: Context) => {
-          // TODO: Add support for creating default VPCs (only one is allowed, also add constraint
-          // that a single VPC is set as default)
-          const client = await ctx.getAwsClient() as AWS;
+      read: async (ctx: Context, id?: string) => {
+        const client = await ctx.getAwsClient() as AWS;
+        // TODO: Convert AWS subnet representation to our own
+        if (!!id) {
+          const rawSubnet = await getSubnet(client.ec2client, id);
+          if (!rawSubnet) return;
+          return await awsVpcModule.subnetMapper(rawSubnet, ctx);
+        } else {
           const out = [];
-          for (const e of es) {
-            let tgs: Tag[] = [];
-            if (e.tags !== undefined && e.tags !== null) {
-              const tags: {[key: string]: string} = e.tags;
-              tgs = Object.keys(tags).map(k => {
-                return {
-                  Key: k, Value: tags[k]
-                }
-              });
-            }
-
-            const input: CreateVpcCommandInput = {
-              CidrBlock: e.cidrBlock,
-            };
-
-            if (tgs.length>0) {
-              input.TagSpecifications=[
-                {
-                  ResourceType: 'vpc',
-                  Tags: tgs,
-                },
-              ]
-            };
-            const res: AwsVpc | undefined = await createVpc(client.ec2client, input);
-            if (res) {
-              const newVpc = await AwsVpcModule.utils.vpcMapper(res, ctx);
-              newVpc.id = e.id;
-              await AwsVpcModule.mappers.vpc.db.update(newVpc, ctx);
-              out.push(newVpc);
-            }
+          for (const sn of await getSubnets(client.ec2client)) {
+            const sub = await awsVpcModule.subnetMapper(sn, ctx);
+            if (sub) out.push(sub);
           }
-
           return out;
-        },
-        read: async (ctx: Context, id?: string) => {
-          const client = await ctx.getAwsClient() as AWS;
-          if (!!id) {
-            const rawVpc = await getVpc(client.ec2client, id);
-            if (!rawVpc) return;
-            return AwsVpcModule.utils.vpcMapper(rawVpc);
+        }
+      },
+      update: async (es: Subnet[], ctx: Context) => {
+        // There is no update mechanism for a subnet so instead we will create a new one and the
+        // next loop through should delete the old one
+        const out = await awsVpcModule.subnet.cloud.create(es, ctx);
+        if (out && !(out instanceof Array)) return [out];
+        return out; 
+      },
+      delete: async (es: Subnet[], ctx: Context) => {
+        const client = await ctx.getAwsClient() as AWS;
+        for (const e of es) {
+          // Special behavior here. You're not allowed to mess with the "default" VPC or its subnets.
+          // Any attempt to update it is instead turned into *restoring* the value in
+          // the database to match the cloud value
+          if (e.vpc?.isDefault) {
+            // For delete, we have un-memoed the record, but the record passed in *is* the one
+            // we're interested in, which makes it a bit simpler here
+            const vpc = ctx?.memo?.db?.Vpc[e.vpc.vpcId ?? ''] ?? null;
+            e.vpc.id = vpc.id;
+            await awsVpcModule.subnet.db.update(e, ctx);
+            // Make absolutely sure it shows up in the memo
+            ctx.memo.db.Subnet[e.subnetId ?? ''] = e;
           } else {
-            return (await getVpcs(client.ec2client))
-              .map(vpc => AwsVpcModule.utils.vpcMapper(vpc));
+            await deleteSubnet(client.ec2client, {
+              SubnetId: e.subnetId,
+            });
           }
-        },
-        update: async (es: Vpc[], ctx: Context) => {
-          // if user has modified state, restore it. If not, go with replace path
-          const client = await ctx.getAwsClient() as AWS;
+        }
+      },
+    }),
+  })
+
+  vpc = new Mapper2<Vpc>({
+    entity: Vpc,
+    equals: (a: Vpc, b: Vpc) => {
+      const result = Object.is(a.cidrBlock, b.cidrBlock) && Object.is(a.state, b.state) && Object.is(a.isDefault, b.isDefault) &&
+        (awsVpcModule.eqTags(a.tags, b.tags));
+      return result;
+    },
+    source: 'db',
+    cloud: new Crud2({
+      updateOrReplace: (a: Vpc, b: Vpc) => {
+        if (!Object.is(a.cidrBlock, b.cidrBlock) || !Object.is(a.isDefault, b.isDefault)) return "replace";
+        else return "update";
+      },
+      create: async (es: Vpc[], ctx: Context) => {
+        // TODO: Add support for creating default VPCs (only one is allowed, also add constraint
+        // that a single VPC is set as default)
+        const client = await ctx.getAwsClient() as AWS;
+        const out = [];
+        for (const e of es) {
+          let tgs: Tag[] = [];
+          if (e.tags !== undefined && e.tags !== null) {
+            const tags: {[key: string]: string} = e.tags;
+            tgs = Object.keys(tags).map(k => {
+              return {
+                Key: k, Value: tags[k]
+              }
+            });
+          }
+
+          const input: CreateVpcCommandInput = {
+            CidrBlock: e.cidrBlock,
+          };
+
+          if (tgs.length>0) {
+            input.TagSpecifications=[
+              {
+                ResourceType: 'vpc',
+                Tags: tgs,
+              },
+            ]
+          };
+          const res: AwsVpc | undefined = await createVpc(client.ec2client, input);
+          if (res) {
+            const newVpc = awsVpcModule.vpcMapper(res);
+            if (!newVpc) continue;
+            newVpc.id = e.id;
+            await awsVpcModule.vpc.db.update(newVpc, ctx);
+            out.push(newVpc);
+          }
+        }
+
+        return out;
+      },
+      read: async (ctx: Context, id?: string) => {
+        const client = await ctx.getAwsClient() as AWS;
+        if (!!id) {
+          const rawVpc = await getVpc(client.ec2client, id);
+          if (!rawVpc) return;
+          return awsVpcModule.vpcMapper(rawVpc);
+        } else {
+          // Typescript doesn't understand filter altering the output type :(
+          const vpcs = await getVpcs(client.ec2client);
           const out = [];
-          for (const e of es) {
-            const cloudRecord = ctx?.memo?.cloud?.Vpc?.[e.vpcId ?? ''];
-            if (!Object.is(e.state, cloudRecord.state)) {
+          for (const vpc of vpcs) {
+            const outVpc = awsVpcModule.vpcMapper(vpc);
+            if (outVpc) out.push(outVpc);
+          }
+          return out;
+        }
+      },
+      update: async (es: Vpc[], ctx: Context) => {
+        // if user has modified state, restore it. If not, go with replace path
+        const client = await ctx.getAwsClient() as AWS;
+        const out = [];
+        for (const e of es) {
+          const cloudRecord = ctx?.memo?.cloud?.Vpc?.[e.vpcId ?? ''];
+          if (!Object.is(e.state, cloudRecord.state)) {
+            // Restore record
+            cloudRecord.id = e.id;
+            await awsVpcModule.vpc.db.update(cloudRecord, ctx);
+            out.push(cloudRecord);
+          } else {
+            const isUpdate = Object.is(awsVpcModule.vpc.cloud.updateOrReplace(cloudRecord, e), 'update');
+            if (!isUpdate) {
+              // if CIDR is different we do the create
+              const newVpc = await awsVpcModule.vpc.cloud.create(e, ctx) as Vpc; // TODO: Make this typesafe
+              out.push(newVpc);
+            } else {
+              if (!awsVpcModule.eqTags(e.tags, cloudRecord.tags) && e.vpcId) {
+                await updateTags(client.ec2client, e.vpcId, e.tags);
+              }
+              out.push(e);
+            }
+          }
+        }
+        return out;
+      },
+      delete: async (es: Vpc[], ctx: Context) => {
+        const client = await ctx.getAwsClient() as AWS;
+        for (const e of es) {
+          // Special behavior here. You're not allowed to mess with the "default" VPC.
+          // Any attempt to update it is instead turned into *restoring* the value in
+          // the database to match the cloud value
+          if (e.isDefault) {
+            // For delete, we have un-memoed the record, but the record passed in *is* the one
+            // we're interested in, which makes it a bit simpler here
+            await awsVpcModule.vpc.db.update(e, ctx);
+            // Make absolutely sure it shows up in the memo
+            ctx.memo.db.Vpc[e.vpcId ?? ''] = e;
+            const subnets = ctx?.memo?.cloud?.Subnet ?? [];
+            const relevantSubnets = subnets.filter(
+              (s: Subnet) => s.vpc.vpcId === e.vpcId
+            );
+            if (relevantSubnets.length > 0) {
+              await awsVpcModule.subnet.db.update(relevantSubnets, ctx);
+            }
+          } else {
+            await deleteVpc(client.ec2client, {
+              VpcId: e.vpcId,
+            });
+          }
+        }
+      },
+    }),
+  })
+
+  natGateway = new Mapper2<NatGateway>({
+    entity: NatGateway,
+    equals: (a: NatGateway, b: NatGateway) => Object.is(a.connectivityType, b.connectivityType)
+      && Object.is(a.elasticIp?.allocationId, b.elasticIp?.allocationId)
+      && Object.is(a.state, b.state)
+      && Object.is(a.subnet?.subnetArn, b.subnet?.subnetArn)
+      && awsVpcModule.eqTags(a.tags, b.tags),
+    source: 'db',
+    cloud: new Crud2({
+      create: async (es: NatGateway[], ctx: Context) => {
+        const out = [];
+        const client = await ctx.getAwsClient() as AWS;
+        for (const e of es) {
+          const input: CreateNatGatewayCommandInput = {
+            SubnetId: e.subnet?.subnetId,
+            ConnectivityType: e.connectivityType,
+          };
+          if (e.tags && Object.keys(e.tags).length) {
+            const tags: Tag[] = Object.keys(e.tags).map((k: string) => {
+              return {
+                Key: k, Value: e.tags![k],
+              }
+            });
+            input.TagSpecifications = [
+              {
+                ResourceType: 'natgateway',
+                Tags: tags,
+              },
+            ]
+          }
+          if (e.elasticIp) {
+            input.AllocationId = e.elasticIp.allocationId;
+            if (!input.AllocationId) throw new Error('Elastic ip need to be created first');
+          } else if (!e.elasticIp && e.connectivityType === ConnectivityType.PUBLIC) {
+            const elasticIp = new ElasticIp();
+            // Attach the same tags in case we want to associate them visualy through the AWS Console
+            elasticIp.tags = e.tags;
+            const newElasticIp = await awsVpcModule.elasticIp.cloud.create(elasticIp, ctx);
+            if (!newElasticIp || newElasticIp instanceof Array) continue;
+            input.AllocationId = newElasticIp.allocationId;
+          }
+          const res: AwsNatGateway | undefined = await createNatGateway(client.ec2client, input);
+          if (res) {
+            const newNatGateway = await awsVpcModule.natGatewayMapper(res, ctx);
+            if (!newNatGateway) continue;
+            newNatGateway.id = e.id;
+            await awsVpcModule.natGateway.db.update(newNatGateway, ctx);
+            out.push(newNatGateway);
+          }
+        }
+        return out;
+      },
+      read: async (ctx: Context, id?: string) => {
+        const client = await ctx.getAwsClient() as AWS;
+        if (!!id) {
+          const rawNatGateway = await getNatGateway(client.ec2client, id);
+          if (!rawNatGateway) return;
+          return await awsVpcModule.natGatewayMapper(rawNatGateway, ctx);
+        } else {
+          const out = [];
+          for (const ng of (await getNatGateways(client.ec2client))) {
+            const outNat = await awsVpcModule.natGatewayMapper(ng, ctx);
+            if (outNat) out.push(outNat);
+          }
+          return out;
+        }
+      },
+      updateOrReplace: (a: NatGateway, b: NatGateway) => {
+        if (!(Object.is(a.state, b.state) && awsVpcModule.eqTags(a.tags, b.tags))
+          && Object.is(a.connectivityType, b.connectivityType)
+          && Object.is(a.elasticIp?.allocationId, b.elasticIp?.allocationId)
+          && Object.is(a.subnet?.subnetId, b.subnet?.subnetId)) return 'update';
+        return 'replace';
+      },
+      update: async (es: NatGateway[], ctx: Context) => {
+        const client = await ctx.getAwsClient() as AWS;
+        const out = [];
+        for (const e of es) {
+          const cloudRecord = ctx?.memo?.cloud?.NatGateway?.[e.natGatewayId ?? ''];
+          // `isUpdate` means only `tags` and/or `state` have changed
+          const isUpdate = Object.is(awsVpcModule.natGateway.cloud.updateOrReplace(cloudRecord, e), 'update');
+          if (isUpdate && !awsVpcModule.eqTags(cloudRecord.tags, e.tags)) {
+            // If `tags` have changed, no matter if `state` changed or not, we update the tags, call AWS and update the DB
+            await updateTags(client.ec2client, e.natGatewayId ?? '', e.tags);
+            const rawNatGateway = await getNatGateway(client.ec2client, e.natGatewayId ?? '');
+            if (!rawNatGateway) continue;
+            const updatedNatGateway = await awsVpcModule.natGatewayMapper(rawNatGateway, ctx);
+            if (!updatedNatGateway) continue;
+            updatedNatGateway.id = e.id;
+            await awsVpcModule.natGateway.db.update(updatedNatGateway, ctx);
+            out.push(updatedNatGateway);
+          } else if (isUpdate && awsVpcModule.eqTags(cloudRecord.tags, e.tags)) {
+            // If `tags` have **not** changed, it means only `state` changed. This is the restore path. We do not call AWS again, just use the record we have in memo.
+            cloudRecord.id = e.id;
+            await awsVpcModule.natGateway.db.update(cloudRecord, ctx);
+            out.push(cloudRecord);
+          } else {
+            // Replace path
+            // Need to delete first to make the elastic ip address available
+            await awsVpcModule.natGateway.cloud.delete(cloudRecord, ctx);
+            const newNatGateway = await awsVpcModule.natGateway.cloud.create(e, ctx) as NatGateway;
+            out.push(newNatGateway);
+          }
+        }
+        return out;
+      },
+      delete: async (es: NatGateway[], ctx: Context) => {
+        const client = await ctx.getAwsClient() as AWS;
+        for (const e of es) {
+          await deleteNatGateway(client.ec2client, e.natGatewayId ?? '');
+        }
+      },
+    }),
+  })
+
+  elasticIp = new Mapper2<ElasticIp>({
+    entity: ElasticIp,
+    equals: (a: ElasticIp, b: ElasticIp) => Object.is(a.publicIp, b.publicIp)
+      && awsVpcModule.eqTags(a.tags, b.tags),
+    source: 'db',
+    cloud: new Crud2({
+      create: async (es: ElasticIp[], ctx: Context) => {
+        const out = [];
+        const client = await ctx.getAwsClient() as AWS;
+        for (const e of es) {
+          const res = await createElasticIp(client.ec2client, e.tags);
+          const rawElasticIp = await getElasticIp(client.ec2client, res.AllocationId ?? '');
+          const newElasticIp = awsVpcModule.elasticIpMapper(rawElasticIp);
+          if (!newElasticIp) continue;
+          newElasticIp.id = e.id;
+          await awsVpcModule.elasticIp.db.update(newElasticIp, ctx);
+          out.push(newElasticIp);
+        }
+        return out;
+      },
+      read: async (ctx: Context, id?: string) => {
+        const client = await ctx.getAwsClient() as AWS;
+        if (!!id) {
+          const rawElasticIp = await getElasticIp(client.ec2client, id);
+          if (!rawElasticIp) return;
+          return awsVpcModule.elasticIpMapper(rawElasticIp);
+        } else {
+          const out = [];
+          for (const eip of (await getElasticIps(client.ec2client))) {
+            const outIp = awsVpcModule.elasticIpMapper(eip);
+            if (outIp) out.push(outIp);
+          }
+          return out;
+        }
+      },
+      update: async (es: ElasticIp[], ctx: Context) => {
+        const client = await ctx.getAwsClient() as AWS;
+        // Elastic ip properties cannot be updated other than tags.
+        // If the public ip is updated we just restor it
+        const out = [];
+        for (const e of es) {
+          const cloudRecord = ctx?.memo?.cloud?.ElasticIp?.[e.allocationId ?? ''];
+          if (e.tags && !awsVpcModule.eqTags(cloudRecord.tags, e.tags)) {
+            await updateTags(client.ec2client, e.allocationId ?? '', e.tags);
+            const rawElasticIp = await getElasticIp(client.ec2client, e.allocationId ?? '');
+            const newElasticIp = awsVpcModule.elasticIpMapper(rawElasticIp);
+            if (!newElasticIp) continue;
+            newElasticIp.id = e.id;
+            await awsVpcModule.elasticIp.db.update(newElasticIp, ctx);
+            // Push
+            out.push(newElasticIp);
+            continue;
+          }
+          cloudRecord.id = e.id;
+          await awsVpcModule.elasticIp.db.update(cloudRecord, ctx);
+          out.push(cloudRecord);
+        }
+        return out;
+      },
+      delete: async (es: ElasticIp[], ctx: Context) => {
+        const client = await ctx.getAwsClient() as AWS;
+        for (const e of es) {
+          await deleteElasticIp(client.ec2client, e.allocationId ?? '');
+        }
+      },
+    }),
+  })
+
+  endpointGateway = new Mapper2<EndpointGateway>({
+    entity: EndpointGateway,
+    equals: (a: EndpointGateway, b: EndpointGateway) => Object.is(a.service, b.service)
+      // the policy document is stringified json
+      // we are trusting aws won't change it from under us
+      && Object.is(a.policyDocument, b.policyDocument)
+      && Object.is(a.state, b.state)
+      && Object.is(a.vpc?.vpcId, b.vpc?.vpcId)
+      && Object.is(a.routeTableIds?.length, b.routeTableIds?.length)
+      && !!a.routeTableIds?.every(art => !!b.routeTableIds?.find(brt => Object.is(art, brt)))
+      && awsVpcModule.eqTags(a.tags, b.tags),
+    source: 'db',
+    cloud: new Crud2({
+      create: async (es: EndpointGateway[], ctx: Context) => {
+        const out = [];
+        const client = await ctx.getAwsClient() as AWS;
+        for (const e of es) {
+          const input: CreateVpcEndpointCommandInput = {
+            VpcEndpointType: 'Gateway',
+            ServiceName: await getVpcEndpointGatewayServiceName(client.ec2client, e.service),
+            VpcId: e.vpc?.vpcId,
+          };
+          if (e.policyDocument) {
+            input.PolicyDocument = e.policyDocument;
+          }
+          if (e.routeTableIds?.length) {
+            input.RouteTableIds = e.routeTableIds;
+          } else {
+            const vpcRouteTables = await getVpcRouteTables(client.ec2client, e.vpc?.vpcId ?? '');
+            input.RouteTableIds = vpcRouteTables?.map(rt => rt.RouteTableId ?? '')?.filter(id => !!id) ?? [];
+          }
+          if (e.tags && Object.keys(e.tags).length) {
+            const tags: Tag[] = Object.keys(e.tags).map((k: string) => {
+              return {
+                Key: k, Value: e.tags![k],
+              }
+            });
+            input.TagSpecifications = [
+              {
+                ResourceType: 'vpc-endpoint',
+                Tags: tags,
+              },
+            ];
+          }
+          const res = await createVpcEndpointGateway(client.ec2client, input);
+          const rawEndpointGateway = await getVpcEndpointGateway(client.ec2client, res?.VpcEndpointId ?? '');
+          if (!rawEndpointGateway) continue;
+          const newEndpointGateway = await awsVpcModule.endpointGatewayMapper(rawEndpointGateway, ctx);
+          if (!newEndpointGateway) continue;
+          newEndpointGateway.id = e.id;
+          await awsVpcModule.endpointGateway.db.update(newEndpointGateway, ctx);
+          out.push(newEndpointGateway);
+        }
+        return out;
+      },
+      read: async (ctx: Context, id?: string) => {
+        const client = await ctx.getAwsClient() as AWS;
+        if (!!id) {
+          const rawEndpointGateway = await getVpcEndpointGateway(client.ec2client, id);
+          if (!rawEndpointGateway) return;
+          return await awsVpcModule.endpointGatewayMapper(rawEndpointGateway, ctx);
+        } else {
+          const out = [];
+          for (const eg of (await getVpcEndpointGateways(client.ec2client))) {
+            const outEndpoint = await awsVpcModule.endpointGatewayMapper(eg, ctx);
+            if (outEndpoint) out.push(outEndpoint);
+          }
+          return out;
+        }
+      },
+      updateOrReplace: (a: EndpointGateway, b: EndpointGateway) => {
+        if (!(Object.is(a.vpc?.vpcId, b.vpc?.vpcId) && Object.is(a.service, b.service))) return 'replace';
+        return 'update';
+      },
+      update: async (es: EndpointGateway[], ctx: Context) => {
+        const client = await ctx.getAwsClient() as AWS;
+        const out = [];
+        for (const e of es) {
+          const cloudRecord = ctx?.memo?.cloud?.EndpointGateway?.[e.vpcEndpointId ?? ''];
+          const isUpdate = awsVpcModule.endpointGateway.cloud.updateOrReplace(cloudRecord, e) === 'update';
+          if (isUpdate) {
+            let update = false;
+            if (!Object.is(cloudRecord.policyDocument, e.policyDocument)) {
+              // VPC endpoint policy document update
+              const input: ModifyVpcEndpointCommandInput = {
+                VpcEndpointId: e.vpcEndpointId,
+                PolicyDocument: e.policyDocument,
+                ResetPolicy: !e.policyDocument
+              };
+              await modifyVpcEndpointGateway(client.ec2client, input);
+              update = true;
+            }
+            if (!(Object.is(cloudRecord.routeTableIds?.length, e.routeTableIds?.length)
+                && !!cloudRecord.routeTableIds?.every((crrt: any) => !!e.routeTableIds?.find(ert => Object.is(crrt, ert))))) {
+              // VPC endpoint route tables update
+              const input: ModifyVpcEndpointCommandInput = {
+                VpcEndpointId: e.vpcEndpointId,
+                RemoveRouteTableIds: cloudRecord.routeTableIds,
+                AddRouteTableIds: e.routeTableIds,
+              };
+              await modifyVpcEndpointGateway(client.ec2client, input);
+              update = true;
+            }
+            if (!awsVpcModule.eqTags(cloudRecord.tags, e.tags)) {
+              // Tags update
+              await updateTags(client.ec2client, e.vpcEndpointId ?? '', e.tags);
+              update = true;
+            }
+            if (update) {
+              const rawEndpointGateway = await getVpcEndpointGateway(client.ec2client, e.vpcEndpointId ?? '');
+              if (!rawEndpointGateway) continue;
+              const newEndpointGateway = await awsVpcModule.endpointGatewayMapper(rawEndpointGateway, ctx);
+              if (!newEndpointGateway) continue;
+              newEndpointGateway.id = e.id;
+              await awsVpcModule.endpointGateway.db.update(newEndpointGateway, ctx);
+              out.push(newEndpointGateway);
+            } else {
               // Restore record
               cloudRecord.id = e.id;
-              await AwsVpcModule.mappers.vpc.db.update(cloudRecord, ctx);
+              await awsVpcModule.endpointGateway.db.update(cloudRecord, ctx);
               out.push(cloudRecord);
-            } else {
-              const isUpdate = Object.is(AwsVpcModule.mappers.vpc.cloud.updateOrReplace(cloudRecord, e), 'update');
-              if (!isUpdate) {
-                // if CIDR is different we do the create
-                const newVpc = await AwsVpcModule.mappers.vpc.cloud.create(e, ctx);
-                out.push(newVpc);
-              } else {
-                if (!AwsVpcModule.utils.eqTags(e.tags, cloudRecord.tags) && e.vpcId) {
-                  await updateTags(client.ec2client, e.vpcId, e.tags);
-                }
-                out.push(e);
-              }
             }
-          }
-          return out;
-        },
-        delete: async (es: Vpc[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            // Special behavior here. You're not allowed to mess with the "default" VPC.
-            // Any attempt to update it is instead turned into *restoring* the value in
-            // the database to match the cloud value
-            if (e.isDefault) {
-              // For delete, we have un-memoed the record, but the record passed in *is* the one
-              // we're interested in, which makes it a bit simpler here
-              await AwsVpcModule.mappers.vpc.db.update(e, ctx);
-              // Make absolutely sure it shows up in the memo
-              ctx.memo.db.Vpc[e.vpcId ?? ''] = e;
-              const subnets = ctx?.memo?.cloud?.Subnet ?? [];
-              const relevantSubnets = subnets.filter(
-                (s: Subnet) => s.vpc.vpcId === e.vpcId
-              );
-              if (relevantSubnets.length > 0) {
-                await AwsVpcModule.mappers.subnet.db.update(relevantSubnets, ctx);
-              }
-            } else {
-              await deleteVpc(client.ec2client, {
-                VpcId: e.vpcId,
-              });
-            }
-          }
-        },
-      }),
-    }),
-    natGateway: new Mapper2<NatGateway>({
-      entity: NatGateway,
-      equals: (a: NatGateway, b: NatGateway) => Object.is(a.connectivityType, b.connectivityType)
-        && Object.is(a.elasticIp?.allocationId, b.elasticIp?.allocationId)
-        && Object.is(a.state, b.state)
-        && Object.is(a.subnet?.subnetArn, b.subnet?.subnetArn)
-        && AwsVpcModule.utils.eqTags(a.tags, b.tags),
-      source: 'db',
-      cloud: new Crud2({
-        create: async (es: NatGateway[], ctx: Context) => {
-          const out = [];
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            const input: CreateNatGatewayCommandInput = {
-              SubnetId: e.subnet?.subnetId,
-              ConnectivityType: e.connectivityType,
-            };
-            if (e.tags && Object.keys(e.tags).length) {
-              const tags: Tag[] = Object.keys(e.tags).map((k: string) => {
-                return {
-                  Key: k, Value: e.tags![k],
-                }
-              });
-              input.TagSpecifications = [
-                {
-                  ResourceType: 'natgateway',
-                  Tags: tags,
-                },
-              ]
-            }
-            if (e.elasticIp) {
-              input.AllocationId = e.elasticIp.allocationId;
-              if (!input.AllocationId) throw new Error('Elastic ip need to be created first');
-            } else if (!e.elasticIp && e.connectivityType === ConnectivityType.PUBLIC) {
-              const elasticIp = new ElasticIp();
-              // Attach the same tags in case we want to associate them visualy through the AWS Console
-              elasticIp.tags = e.tags;
-              const newElasticIp = await AwsVpcModule.mappers.elasticIp.cloud.create(elasticIp, ctx);
-              input.AllocationId = newElasticIp.allocationId;
-            }
-            const res: AwsNatGateway | undefined = await createNatGateway(client.ec2client, input);
-            if (res) {
-              const newNatGateway = await AwsVpcModule.utils.natGatewayMapper(res, ctx);
-              newNatGateway.id = e.id;
-              await AwsVpcModule.mappers.natGateway.db.update(newNatGateway, ctx);
-              out.push(newNatGateway);
-            }
-          }
-          return out;
-        },
-        read: async (ctx: Context, id?: string) => {
-          const client = await ctx.getAwsClient() as AWS;
-          if (!!id) {
-            const rawNatGateway = await getNatGateway(client.ec2client, id);
-            if (!rawNatGateway) return;
-            return await AwsVpcModule.utils.natGatewayMapper(rawNatGateway, ctx);
           } else {
-            const out = [];
-            for (const ng of (await getNatGateways(client.ec2client))) {
-              out.push(await AwsVpcModule.utils.natGatewayMapper(ng, ctx));
-            }
-            return out;
-          }
-        },
-        updateOrReplace: (a: NatGateway, b: NatGateway) => {
-          if (!(Object.is(a.state, b.state) && AwsVpcModule.utils.eqTags(a.tags, b.tags))
-            && Object.is(a.connectivityType, b.connectivityType)
-            && Object.is(a.elasticIp?.allocationId, b.elasticIp?.allocationId)
-            && Object.is(a.subnet?.subnetId, b.subnet?.subnetId)) return 'update';
-          return 'replace';
-        },
-        update: async (es: NatGateway[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          const out = [];
-          for (const e of es) {
-            const cloudRecord = ctx?.memo?.cloud?.NatGateway?.[e.natGatewayId ?? ''];
-            // `isUpdate` means only `tags` and/or `state` have changed
-            const isUpdate = Object.is(AwsVpcModule.mappers.natGateway.cloud.updateOrReplace(cloudRecord, e), 'update');
-            if (isUpdate && !AwsVpcModule.utils.eqTags(cloudRecord.tags, e.tags)) {
-              // If `tags` have changed, no matter if `state` changed or not, we update the tags, call AWS and update the DB
-              await updateTags(client.ec2client, e.natGatewayId ?? '', e.tags);
-              const rawNatGateway = await getNatGateway(client.ec2client, e.natGatewayId ?? '');
-              const updatedNatGateway = await AwsVpcModule.utils.natGatewayMapper(rawNatGateway, ctx);
-              updatedNatGateway.id = e.id;
-              await AwsVpcModule.mappers.natGateway.db.update(updatedNatGateway, ctx);
-              out.push(updatedNatGateway);
-            } else if (isUpdate && AwsVpcModule.utils.eqTags(cloudRecord.tags, e.tags)) {
-              // If `tags` have **not** changed, it means only `state` changed. This is the restore path. We do not call AWS again, just use the record we have in memo.
-              cloudRecord.id = e.id;
-              await AwsVpcModule.mappers.natGateway.db.update(cloudRecord, ctx);
-              out.push(cloudRecord);
-            } else {
-              // Replace path
-              // Need to delete first to make the elastic ip address available
-              await AwsVpcModule.mappers.natGateway.cloud.delete(cloudRecord, ctx);
-              const newNatGateway = await AwsVpcModule.mappers.natGateway.cloud.create(e, ctx);
-              out.push(newNatGateway);
-            }
-          }
-          return out;
-        },
-        delete: async (es: NatGateway[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            await deleteNatGateway(client.ec2client, e.natGatewayId ?? '');
-          }
-        },
-      }),
-    }),
-    elasticIp: new Mapper2<ElasticIp>({
-      entity: ElasticIp,
-      equals: (a: ElasticIp, b: ElasticIp) => Object.is(a.publicIp, b.publicIp)
-        && AwsVpcModule.utils.eqTags(a.tags, b.tags),
-      source: 'db',
-      cloud: new Crud2({
-        create: async (es: ElasticIp[], ctx: Context) => {
-          const out = [];
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            const res = await createElasticIp(client.ec2client, e.tags);
-            const rawElasticIp = await getElasticIp(client.ec2client, res.AllocationId ?? '');
-            const newElasticIp = AwsVpcModule.utils.elasticIpMapper(rawElasticIp);
-            newElasticIp.id = e.id;
-            await AwsVpcModule.mappers.elasticIp.db.update(newElasticIp, ctx);
-            out.push(newElasticIp);
-          }
-          return out;
-        },
-        read: async (ctx: Context, id?: string) => {
-          const client = await ctx.getAwsClient() as AWS;
-          if (!!id) {
-            const rawElasticIp = await getElasticIp(client.ec2client, id);
-            if (!rawElasticIp) return;
-            return AwsVpcModule.utils.elasticIpMapper(rawElasticIp);
-          } else {
-            const out = [];
-            for (const eip of (await getElasticIps(client.ec2client))) {
-              out.push(AwsVpcModule.utils.elasticIpMapper(eip));
-            }
-            return out;
-          }
-        },
-        update: async (es: ElasticIp[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          // Elastic ip properties cannot be updated other than tags.
-          // If the public ip is updated we just restor it
-          const out = [];
-          for (const e of es) {
-            const cloudRecord = ctx?.memo?.cloud?.ElasticIp?.[e.allocationId ?? ''];
-            if (e.tags && !AwsVpcModule.utils.eqTags(cloudRecord.tags, e.tags)) {
-              await updateTags(client.ec2client, e.allocationId ?? '', e.tags);
-              const rawElasticIp = await getElasticIp(client.ec2client, e.allocationId ?? '');
-              const newElasticIp = AwsVpcModule.utils.elasticIpMapper(rawElasticIp);
-              newElasticIp.id = e.id;
-              await AwsVpcModule.mappers.elasticIp.db.update(newElasticIp, ctx);
-              // Push
-              out.push(newElasticIp);
-              continue;
-            }
-            cloudRecord.id = e.id;
-            await AwsVpcModule.mappers.elasticIp.db.update(cloudRecord, ctx);
-            out.push(cloudRecord);
-          }
-          return out;
-        },
-        delete: async (es: ElasticIp[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            await deleteElasticIp(client.ec2client, e.allocationId ?? '');
-          }
-        },
-      }),
-    }),
-    endpointGateway: new Mapper2<EndpointGateway>({
-      entity: EndpointGateway,
-      equals: (a: EndpointGateway, b: EndpointGateway) => Object.is(a.service, b.service)
-        // the policy document is stringified json
-        // we are trusting aws won't change it from under us
-        && Object.is(a.policyDocument, b.policyDocument)
-        && Object.is(a.state, b.state)
-        && Object.is(a.vpc?.vpcId, b.vpc?.vpcId)
-        && Object.is(a.routeTableIds?.length, b.routeTableIds?.length)
-        && !!a.routeTableIds?.every(art => !!b.routeTableIds?.find(brt => Object.is(art, brt)))
-        && AwsVpcModule.utils.eqTags(a.tags, b.tags),
-      source: 'db',
-      cloud: new Crud2({
-        create: async (es: EndpointGateway[], ctx: Context) => {
-          const out = [];
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            const input: CreateVpcEndpointCommandInput = {
-              VpcEndpointType: 'Gateway',
-              ServiceName: await getVpcEndpointGatewayServiceName(client.ec2client, e.service),
-              VpcId: e.vpc?.vpcId,
-            };
-            if (e.policyDocument) {
-              input.PolicyDocument = e.policyDocument;
-            }
-            if (e.routeTableIds?.length) {
-              input.RouteTableIds = e.routeTableIds;
-            } else {
-              const vpcRouteTables = await getVpcRouteTables(client.ec2client, e.vpc?.vpcId ?? '');
-              input.RouteTableIds = vpcRouteTables?.map(rt => rt.RouteTableId ?? '')?.filter(id => !!id) ?? [];
-            }
-            if (e.tags && Object.keys(e.tags).length) {
-              const tags: Tag[] = Object.keys(e.tags).map((k: string) => {
-                return {
-                  Key: k, Value: e.tags![k],
-                }
-              });
-              input.TagSpecifications = [
-                {
-                  ResourceType: 'vpc-endpoint',
-                  Tags: tags,
-                },
-              ];
-            }
-            const res = await createVpcEndpointGateway(client.ec2client, input);
-            const rawEndpointGateway = await getVpcEndpointGateway(client.ec2client, res?.VpcEndpointId ?? '');
-            const newEndpointGateway = await AwsVpcModule.utils.endpointGatewayMapper(rawEndpointGateway, ctx);
-            newEndpointGateway.id = e.id;
-            await AwsVpcModule.mappers.endpointGateway.db.update(newEndpointGateway, ctx);
+            // Replace record
+            const newEndpointGateway = await awsVpcModule.endpointGateway.cloud.create(e, ctx) as EndpointGateway;
+            await awsVpcModule.endpointGateway.cloud.delete(cloudRecord, ctx);
             out.push(newEndpointGateway);
           }
-          return out;
-        },
-        read: async (ctx: Context, id?: string) => {
-          const client = await ctx.getAwsClient() as AWS;
-          if (!!id) {
-            const rawEndpointGateway = await getVpcEndpointGateway(client.ec2client, id);
-            if (!rawEndpointGateway) return;
-            return await AwsVpcModule.utils.endpointGatewayMapper(rawEndpointGateway, ctx);
-          } else {
-            const out = [];
-            for (const eg of (await getVpcEndpointGateways(client.ec2client))) {
-              out.push(await AwsVpcModule.utils.endpointGatewayMapper(eg, ctx));
-            }
+        }
+        return out;
+      },
+      delete: async (es: EndpointGateway[], ctx: Context) => {
+        const client = await ctx.getAwsClient() as AWS;
+        for (const e of es) {
+          await deleteVpcEndpointGateway(client.ec2client, e.vpcEndpointId ?? '');
+        }
+      },
+    }),
+  })
+
+  availabilityZone: Mapper2<AvailabilityZone> = new Mapper2<AvailabilityZone>({
+    entity: AvailabilityZone,
+    equals: (a: AvailabilityZone, b: AvailabilityZone) => a.name === b.name,
+    source: 'db',
+    cloud: new Crud2({
+      create: async (e: AvailabilityZone[], ctx: Context) => {
+        const out = await awsVpcModule.availabilityZone.db.delete(e, ctx);
+        if (out && !(out instanceof Array)) return [out];
+        return out;
+      },
+      read: async (ctx: Context, name?: string) => {
+        const client = await ctx.getAwsClient() as AWS;
+        const availabilityZones = await getAvailabilityZones(client.ec2client, client.region);
+        const azs = availabilityZones
+          ?.AvailabilityZones
+          ?.filter(az => !!az.ZoneName)
+          .map(az => {
+            const out = new AvailabilityZone();
+            out.name = az.ZoneName as string; // TS should have figured this out from the filter
             return out;
-          }
-        },
-        updateOrReplace: (a: EndpointGateway, b: EndpointGateway) => {
-          if (!(Object.is(a.vpc?.vpcId, b.vpc?.vpcId) && Object.is(a.service, b.service))) return 'replace';
-          return 'update';
-        },
-        update: async (es: EndpointGateway[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          const out = [];
-          for (const e of es) {
-            const cloudRecord = ctx?.memo?.cloud?.EndpointGateway?.[e.vpcEndpointId ?? ''];
-            const isUpdate = AwsVpcModule.mappers.endpointGateway.cloud.updateOrReplace(cloudRecord, e) === 'update';
-            if (isUpdate) {
-              let update = false;
-              if (!Object.is(cloudRecord.policyDocument, e.policyDocument)) {
-                // VPC endpoint policy document update
-                const input: ModifyVpcEndpointCommandInput = {
-                  VpcEndpointId: e.vpcEndpointId,
-                  PolicyDocument: e.policyDocument,
-                  ResetPolicy: !e.policyDocument
-                };
-                await modifyVpcEndpointGateway(client.ec2client, input);
-                update = true;
-              }
-              if (!(Object.is(cloudRecord.routeTableIds?.length, e.routeTableIds?.length)
-                  && !!cloudRecord.routeTableIds?.every((crrt: any) => !!e.routeTableIds?.find(ert => Object.is(crrt, ert))))) {
-                // VPC endpoint route tables update
-                const input: ModifyVpcEndpointCommandInput = {
-                  VpcEndpointId: e.vpcEndpointId,
-                  RemoveRouteTableIds: cloudRecord.routeTableIds,
-                  AddRouteTableIds: e.routeTableIds,
-                };
-                await modifyVpcEndpointGateway(client.ec2client, input);
-                update = true;
-              }
-              if (!AwsVpcModule.utils.eqTags(cloudRecord.tags, e.tags)) {
-                // Tags update
-                await updateTags(client.ec2client, e.vpcEndpointId ?? '', e.tags);
-                update = true;
-              }
-              if (update) {
-                const rawEndpointGateway = await getVpcEndpointGateway(client.ec2client, e.vpcEndpointId ?? '');
-                const newEndpointGateway = await AwsVpcModule.utils.endpointGatewayMapper(rawEndpointGateway, ctx);
-                newEndpointGateway.id = e.id;
-                await AwsVpcModule.mappers.endpointGateway.db.update(newEndpointGateway, ctx);
-                out.push(newEndpointGateway);
-              } else {
-                // Restore record
-                cloudRecord.id = e.id;
-                await AwsVpcModule.mappers.endpointGateway.db.update(cloudRecord, ctx);
-                out.push(cloudRecord);
-              }
-            } else {
-              // Replace record
-              const newEndpointGateway = await AwsVpcModule.mappers.endpointGateway.cloud.create(e, ctx);
-              await AwsVpcModule.mappers.endpointGateway.cloud.delete(cloudRecord, ctx);
-              out.push(newEndpointGateway);
-            }
-          }
-          return out;
-        },
-        delete: async (es: EndpointGateway[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            await deleteVpcEndpointGateway(client.ec2client, e.vpcEndpointId ?? '');
-          }
-        },
-      }),
+          }) ?? [];
+        if (!!name) return azs.filter(az => az.name === name);
+        return azs;
+      },
+      // Update should never happen because the name is the only field
+      update: async (_e: AvailabilityZone[], _ctx: Context) => { /* Do nothing */ },
+      delete: async (e: AvailabilityZone[], ctx: Context) => {
+        const out = await awsVpcModule.availabilityZone.db.create(e, ctx);
+        if (out && !(out instanceof Array)) return [out];
+        return out;
+      },
     }),
-    availabilityZone: new Mapper2<AvailabilityZone>({
-      entity: AvailabilityZone,
-      equals: (a: AvailabilityZone, b: AvailabilityZone) => a.name === b.name,
-      source: 'db',
-      cloud: new Crud2({
-        create: async (e: AvailabilityZone[], ctx: Context) => AwsVpcModule.mappers.availabilityZone.db.delete(e, ctx),
-        read: async (ctx: Context, name?: string) => {
-          const client = await ctx.getAwsClient() as AWS;
-          const availabilityZones = await getAvailabilityZones(client.ec2client, client.region);
-          const azs = availabilityZones
-            ?.AvailabilityZones
-            ?.filter(az => !!az.ZoneName)
-            .map(az => {
-              const out = new AvailabilityZone();
-              out.name = az.ZoneName as string; // TS should have figured this out from the filter
-              return out;
-            }) ?? [];
-          if (!!name) return azs.filter(az => az.name === name);
-          return azs;
-        },
-        // Update should never happen because the name is the only field
-        update: async (_e: AvailabilityZone[], _ctx: Context) => { /* Do nothing */ },
-        delete: async (e: AvailabilityZone[], ctx: Context) => AwsVpcModule.mappers.availabilityZone.db.create(e, ctx),
-      }),
-    }),
-  },
-}, __dirname)
+  })
+}
+export const awsVpcModule = new AwsVpcModule();

--- a/src/modules/0.0.16/aws_vpc/index.ts
+++ b/src/modules/0.0.16/aws_vpc/index.ts
@@ -323,6 +323,7 @@ async function createElasticIp(client: EC2, tags?: { [key: string] : string }) {
 
 class AwsVpcModule extends ModuleBase {
   constructor() { super(); super.init(); }
+  dirname = __dirname;
   dependencies = metadata.dependencies;
 
   async subnetMapper(sn: AwsSubnet, ctx: Context) {
@@ -484,7 +485,7 @@ class AwsVpcModule extends ModuleBase {
         // next loop through should delete the old one
         const out = await awsVpcModule.subnet.cloud.create(es, ctx);
         if (out && !(out instanceof Array)) return [out];
-        return out; 
+        return out;
       },
       delete: async (es: Subnet[], ctx: Context) => {
         const client = await ctx.getAwsClient() as AWS;


### PR DESCRIPTION
Part of #862. This one shows some issues with leaving the Mapper and Crud objects alone. Most things still need to reference the singleton object, so mock-based testing is out of reach (not that that was the main goal here, but eventually getting there seemed reasonable).

Once this PR is passing tests, I am going to think about how to refactor the mappers, too.