### PR TITLE
Class-ify the S3 module

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "homepage": "https://iasql.com",
   "devDependencies": {
+    "@types/callsite": "^1.0.31",
     "@types/cors": "^2.8.12",
     "@types/jest": "^27.5.0",
     "@types/lodash.isequal": "^4.5.6",
@@ -77,6 +78,7 @@
     "@types/lodash.pick": "^4.4.7",
     "@types/semver": "^7.3.10",
     "axios": "^0.27.2",
+    "callsite": "^1.0.0",
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "express-jwt": "^6.1.0",

--- a/src/modules/0.0.17/aws_account/index.ts
+++ b/src/modules/0.0.17/aws_account/index.ts
@@ -1,10 +1,31 @@
 import { AWS, } from '../../../services/aws_macros'
 import { AwsAccountEntity, } from './entity'
-import { Context, Crud2, Mapper2, ModuleBase, } from '../../interfaces'
+import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
 import * as metadata from './module.json' // TODO: Eliminate this?
 
+class AccountMapper extends MapperBase<AwsAccountEntity> {
+  module: AwsAccount;
+  entity = AwsAccountEntity;
+  equals = (_a: AwsAccountEntity, _b: AwsAccountEntity) => true;
+  cloud =  new Crud2<AwsAccountEntity>({
+    create: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
+    read: (ctx: Context, id?: string) => ctx.orm.find(AwsAccountEntity, id ? {
+      where: {
+        id,
+      },
+    } : undefined),
+    update: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
+    delete: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
+  });
+
+  constructor(module: AwsAccount) {
+    super();
+    this.module = module;
+    super.init();
+  }
+}
+
 class AwsAccount extends ModuleBase {
-  constructor() { super(); super.init(); }
   dirname = __dirname;
   dependencies = metadata.dependencies;
   context: Context = {
@@ -30,20 +51,12 @@ class AwsAccount extends ModuleBase {
     },
     awsClient: null, // Just reserving this name to guard against collisions between modules.
   };
-  awsAccount = new Mapper2<AwsAccountEntity>({
-    entity: AwsAccountEntity,
-    equals: (_a: AwsAccountEntity, _b: AwsAccountEntity) => true,
-    source: 'db',
-    cloud: new Crud2({
-      create: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
-      read: (ctx: Context, id?: string) => ctx.orm.find(AwsAccountEntity, id ? {
-        where: {
-          id,
-        },
-      } : undefined),
-      update: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
-      delete: async (_e: AwsAccountEntity[], _ctx: Context) => { /* Do nothing */ },
-    }),
-  });
+  awsAccount: AccountMapper;
+
+  constructor() {
+    super();
+    this.awsAccount = new AccountMapper(this);
+    super.init();
+  }
 }
 export const awsAccount = new AwsAccount();

--- a/src/modules/0.0.17/aws_account/index.ts
+++ b/src/modules/0.0.17/aws_account/index.ts
@@ -26,7 +26,6 @@ class AccountMapper extends MapperBase<AwsAccountEntity> {
 }
 
 class AwsAccount extends ModuleBase {
-  dirname = __dirname;
   dependencies = metadata.dependencies;
   context: Context = {
     // This function is `async function () {` instead of `async () => {` because that enables the

--- a/src/modules/0.0.17/aws_s3/index.ts
+++ b/src/modules/0.0.17/aws_s3/index.ts
@@ -159,7 +159,6 @@ class BucketMapper extends MapperBase<Bucket> {
 }
 
 class AwsS3Module extends ModuleBase {
-  dirname = __dirname;
   dependencies = metadata.dependencies;
   bucket: BucketMapper;
 

--- a/src/modules/0.0.17/aws_s3/index.ts
+++ b/src/modules/0.0.17/aws_s3/index.ts
@@ -1,158 +1,164 @@
-import { S3, Bucket as BucketAWS, GetBucketPolicyCommandInput, PutBucketPolicyCommandInput, ListBucketsCommandInput, CreateBucketCommandInput, CreateBucketCommandOutput } from '@aws-sdk/client-s3'
+import {
+  S3,
+  Bucket as BucketAWS,
+  GetBucketPolicyCommandInput,
+  PutBucketPolicyCommandInput,
+} from '@aws-sdk/client-s3'
 
 import { AWS, crudBuilder2, crudBuilderFormat, } from '../../../services/aws_macros'
-import { Bucket} from './entity'
-import { Context, Crud2, Mapper2, Module2, } from '../../interfaces'
+import { Bucket, } from './entity'
+import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
 import * as metadata from './module.json'
 import isEqual from 'lodash.isequal'
 
-const getBuckets = crudBuilderFormat<S3, 'listBuckets', BucketAWS[]>(
-  'listBuckets',
-  () => ({}),
-  (res) => res?.Buckets ?? [],
-);
-
-const deleteBucket = crudBuilder2<S3, 'deleteBucket'>(
-  'deleteBucket',
-  (b) => ({ Bucket: b, }),
-);
-
-const createBucket = crudBuilder2<S3, 'createBucket'>(
-  'createBucket',
-  (b) => ({ Bucket: b, }),
-);
-
-
-async function getBucketPolicy(client: S3, input: GetBucketPolicyCommandInput) {
-  try {
-    const res = await client.getBucketPolicy(input);
+class BucketMapper extends MapperBase<Bucket> {
+  module: AwsS3Module;
+  entity = Bucket;
+  equals = (a: Bucket, b: Bucket) => {
+    const res = Object.is(a.name, b.name) &&
+    Object.is(a.createdAt?.toISOString(), b.createdAt?.toISOString()) && isEqual(a.policyDocument, b.policyDocument);
     return res;
-  } catch (_) {
-    // policy does not exist, return
-    return null;
+  };
+  getBuckets = crudBuilderFormat<S3, 'listBuckets', BucketAWS[]>(
+    'listBuckets',
+    () => ({}),
+    (res) => res?.Buckets ?? [],
+  );
+  deleteBucket = crudBuilder2<S3, 'deleteBucket'>(
+    'deleteBucket',
+    (b) => ({ Bucket: b, }),
+  );
+  createBucket = crudBuilder2<S3, 'createBucket'>(
+    'createBucket',
+    (b) => ({ Bucket: b, }),
+  );
+  getBucketPolicy = crudBuilder2<S3, 'getBucketPolicy'>('getBucketPolicy', (input) => input);
+  updateBucketPolicy = crudBuilder2<S3, 'putBucketPolicy'>(
+    'putBucketPolicy',
+    (input) => (input),
+  );
+  cloud = new Crud2<Bucket>({
+    // TODO: There are lots of useful permission controls on create to be added to this model
+    create: async (es: Bucket[], ctx: Context) => {
+      const client = await ctx.getAwsClient() as AWS;
+      const out = [];
+      for (const e of es) {
+        await this.createBucket(client.s3Client, e.name);
+        out.push(e);
+      }
+      return out;
+    },
+    read: async (ctx: Context, id?: string) => {
+      const client = await ctx.getAwsClient() as AWS;
+
+      const allBuckets = await this.getBuckets(client.s3Client);
+      const out : Bucket[] = [];
+      const buckets : BucketAWS[] = allBuckets
+          .filter(b => !id || b.Name === id)
+          .filter(b => !!b.Name);
+
+      for (const index in buckets ) {
+        if (buckets.hasOwnProperty(index)) {
+          const bucket = buckets[index];
+
+          // retrieve bucket policy
+          const input: GetBucketPolicyCommandInput = {
+            Bucket: bucket.Name,
+          };
+          const bucketPolicy = await this.getBucketPolicy(client.s3Client, input);
+          const b:Bucket = this.module.bucket.bucketMapper(bucket);
+
+          if (bucketPolicy && bucketPolicy.Policy) {
+            b.policyDocument=JSON.parse(bucketPolicy.Policy);
+          } else {
+            b.policyDocument=undefined;
+          }
+          out.push(b);
+        }
+      }
+      return out;
+    },
+    updateOrReplace: (a: Bucket, b: Bucket) => {
+      if (!Object.is(a.policyDocument, b.policyDocument)) return 'update';
+      else return 'replace';
+    },
+    // TODO: With the model this simple it is actually impossible to really update this thing
+    // as the user can't change the create timestamp themselves, so just restore the record from
+    // the cloud cache and force it into the DB cache
+    update: async (es: Bucket[], ctx: Context) => {
+      const client = await ctx.getAwsClient() as AWS;
+      const out = [];
+      for (const e of es) {
+        const cloudRecord = ctx?.memo?.cloud?.Bucket?.[e.name ?? ''];
+        const isUpdate = Object.is(this.module.bucket.cloud.updateOrReplace(cloudRecord, e), 'update');
+        if (isUpdate) {
+          e.createdAt=cloudRecord.createdAt;
+          e.policyDocument = await this.module.bucket.createBucketPolicy(client.s3Client, e, ctx);
+          out.push(e);
+        } else {
+          // Replace if name has changed
+          await this.module.bucket.db.update(cloudRecord, ctx);
+          ctx.memo.db.Bucket[cloudRecord.name] = cloudRecord;
+          out.push(cloudRecord);
+        }
+      }
+      return out;
+    },
+    delete: async (es: Bucket[], ctx: Context) => {
+      const client = await ctx.getAwsClient() as AWS;
+      for (const e of es) {
+        await this.deleteBucket(client.s3Client, e.name);
+      }
+    },
+  });
+
+  constructor(module: AwsS3Module) {
+    super();
+    this.module = module;
+    super.init();
+  }
+
+  bucketMapper(instance: BucketAWS) {
+    const b: Bucket = new Bucket();
+    if (!instance.Name) throw new Error('Received a bucket without a name');
+    b.name = instance.Name;
+    b.createdAt = instance.CreationDate;
+    return b;
+  }
+
+  async createBucketPolicy(client: S3, bucket: Bucket, ctx: Context) {
+    const input : PutBucketPolicyCommandInput = {
+      Bucket: bucket.name,
+      Policy: JSON.stringify(bucket.policyDocument ?? {}),
+    };
+    await this.updateBucketPolicy(client, input);
+    await this.module.bucket.db.update(bucket, ctx);
+
+    // requery the created policy from AWS
+    const inputGet: GetBucketPolicyCommandInput = {
+      Bucket: bucket.name,
+    };
+    const bucketPolicy = await this.getBucketPolicy(client, inputGet);
+    if (bucketPolicy && bucketPolicy.Policy) {
+      bucket.policyDocument=JSON.parse(bucketPolicy.Policy);
+    } else {
+      bucket.policyDocument=undefined;
+    }
+    await this.module.bucket.db.update(bucket, ctx);
+
+    return bucket.policyDocument;
   }
 }
+  
+class AwsS3Module extends ModuleBase {
+  dirname = __dirname;
+  dependencies = metadata.dependencies;
+  bucket: BucketMapper;
 
-const updateBucketPolicy = crudBuilder2<S3, 'putBucketPolicy'>(
-  'putBucketPolicy',
-  (input) => (input),
-);
-
-export const AwsS3Module: Module2 = new Module2({
-  ...metadata,
-  utils: {
-    bucketMapper: async (instance: BucketAWS, ctx: Context) => {
-      const b:Bucket = new Bucket();
-      b.name=instance.Name!;
-      b.createdAt=instance.CreationDate;
-      return b
-    },
-    createBucketPolicy: async (client: S3, bucket: Bucket, ctx: Context) => {
-      const input : PutBucketPolicyCommandInput = {
-        Bucket: bucket.name,
-        Policy: JSON.stringify(bucket.policyDocument ?? {}),
-      };
-      await updateBucketPolicy(client, input);
-      await AwsS3Module.mappers.bucket.db.update(bucket, ctx);
-
-      // requery the created policy from AWS
-      const inputGet: GetBucketPolicyCommandInput = {
-        Bucket: bucket.name,
-      };
-      const bucketPolicy = await getBucketPolicy(client, inputGet);
-      if (bucketPolicy && bucketPolicy.Policy) {
-        bucket.policyDocument=JSON.parse(bucketPolicy.Policy);
-      } else {
-        bucket.policyDocument=undefined;
-      }
-      await AwsS3Module.mappers.bucket.db.update(bucket, ctx);
-
-      return bucket.policyDocument;
-    },
-  },
-  mappers: {
-    bucket: new Mapper2<Bucket>({
-      entity: Bucket,
-      equals: (a: Bucket, b: Bucket) => {
-        const res = Object.is(a.name, b.name) &&
-        Object.is(a.createdAt?.toISOString(), b.createdAt?.toISOString()) && isEqual(a.policyDocument, b.policyDocument);
-        return res;
-      },
-      source: 'db',
-      cloud: new Crud2({
-        // TODO: There are lots of useful permission controls on create to be added to this model
-        create: async (es: Bucket[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          const out = [];
-          for (const e of es) {
-            await createBucket(client.s3Client, e.name);
-            out.push(e);
-          }
-          return out;
-        },
-        read: async (ctx: Context, id?: string) => {
-          const client = await ctx.getAwsClient() as AWS;
-
-          const allBuckets = await getBuckets(client.s3Client);
-          const out : Bucket[] = [];
-          const buckets : BucketAWS[] = allBuckets
-              .filter(b => !id || b.Name === id)
-              .filter(b => !!b.Name);
-
-          for (const index in buckets ) {
-            if (buckets.hasOwnProperty(index)) {
-              const bucket = buckets[index];
-
-              // retrieve bucket policy
-              const input: GetBucketPolicyCommandInput = {
-                Bucket: bucket.Name,
-              };
-              const bucketPolicy = await getBucketPolicy(client.s3Client, input);
-              const b:Bucket = await AwsS3Module.utils.bucketMapper(bucket);
-
-              if (bucketPolicy && bucketPolicy.Policy) {
-                b.policyDocument=JSON.parse(bucketPolicy.Policy);
-              } else {
-                b.policyDocument=undefined;
-              }
-              out.push(b);
-            }
-          }
-          return out;
-        },
-        updateOrReplace: (a: Bucket, b: Bucket) => {
-          if (!Object.is(a.policyDocument, b.policyDocument)) return 'update';
-          else return 'replace';
-        },
-        // TODO: With the model this simple it is actually impossible to really update this thing
-        // as the user can't change the create timestamp themselves, so just restore the record from
-        // the cloud cache and force it into the DB cache
-        update: async (es: Bucket[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          const out = [];
-          for (const e of es) {
-            const cloudRecord = ctx?.memo?.cloud?.Bucket?.[e.name ?? ''];
-            const isUpdate = Object.is(AwsS3Module.mappers.bucket.cloud.updateOrReplace(cloudRecord, e), 'update');
-            if (isUpdate) {
-              e.createdAt=cloudRecord.createdAt;
-              e.policyDocument = await AwsS3Module.utils.createBucketPolicy(client.s3Client, e, ctx);
-              out.push(e);
-            } else {
-              // Replace if name has changed
-              await AwsS3Module.mappers.bucket.db.update(cloudRecord, ctx);
-              ctx.memo.db.Bucket[cloudRecord.name] = cloudRecord;
-              out.push(cloudRecord);
-            }
-          }
-          return out;
-        },
-        delete: async (es: Bucket[], ctx: Context) => {
-          const client = await ctx.getAwsClient() as AWS;
-          for (const e of es) {
-            await deleteBucket(client.s3Client, e.name);
-          }
-        },
-      }),
-    }),
-  },
-}, __dirname)
+  constructor() {
+    super();
+    this.bucket = new BucketMapper(this);
+    super.init();
+  }
+}
+export const awsS3Module = new AwsS3Module();

--- a/src/modules/0.0.17/aws_s3/index.ts
+++ b/src/modules/0.0.17/aws_s3/index.ts
@@ -149,7 +149,7 @@ class BucketMapper extends MapperBase<Bucket> {
     return bucket.policyDocument;
   }
 }
-  
+
 class AwsS3Module extends ModuleBase {
   dirname = __dirname;
   dependencies = metadata.dependencies;

--- a/src/modules/0.0.17/aws_s3/index.ts
+++ b/src/modules/0.0.17/aws_s3/index.ts
@@ -32,7 +32,15 @@ class BucketMapper extends MapperBase<Bucket> {
     'createBucket',
     (b) => ({ Bucket: b, }),
   );
-  getBucketPolicy = crudBuilder2<S3, 'getBucketPolicy'>('getBucketPolicy', (input) => input);
+  async getBucketPolicy(client: S3, input: GetBucketPolicyCommandInput) {
+    try {
+      const res = await client.getBucketPolicy(input);
+      return res;
+    } catch (_) {
+      // policy does not exist, return
+      return null;
+    }
+  }
   updateBucketPolicy = crudBuilder2<S3, 'putBucketPolicy'>(
     'putBucketPolicy',
     (input) => (input),
@@ -66,7 +74,7 @@ class BucketMapper extends MapperBase<Bucket> {
             Bucket: bucket.Name,
           };
           const bucketPolicy = await this.getBucketPolicy(client.s3Client, input);
-          const b:Bucket = this.module.bucket.bucketMapper(bucket);
+          const b: Bucket = this.module.bucket.bucketMapper(bucket);
 
           if (bucketPolicy && bucketPolicy.Policy) {
             b.policyDocument=JSON.parse(bucketPolicy.Policy);

--- a/src/modules/0.0.17/iasql_functions/index.ts
+++ b/src/modules/0.0.17/iasql_functions/index.ts
@@ -6,7 +6,6 @@ import { ModuleBase, } from '../../interfaces'
 
 class IasqlFunctions extends ModuleBase {
   constructor() { super(); super.init(); }
-  dirname = __dirname;
   dependencies = metadata.dependencies;
   iasqlOperationType = IasqlOperationType;
 }

--- a/src/modules/0.0.17/iasql_platform/index.ts
+++ b/src/modules/0.0.17/iasql_platform/index.ts
@@ -6,7 +6,6 @@ import { IasqlModule, IasqlTables, } from './entity'
 
 class IasqlPlatform extends ModuleBase {
   constructor() { super(); super.init(); }
-  dirname = __dirname;
   dependencies = metadata.dependencies;
   iasqlModule = IasqlModule;
   iasqlTables = IasqlTables;

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -2,7 +2,9 @@ import fs from 'fs'
 import path from 'path'
 
 import { QueryRunner, getMetadataArgsStorage, } from 'typeorm'
+import callsite from 'callsite'
 
+import { throwError, } from '../config/config'
 import { getCloudId, } from '../services/cloud-id'
 import logger from '../services/logger'
 
@@ -462,7 +464,10 @@ export class ModuleBase {
   };
 
   init() {
-    if (!this.dirname) throw new Error('Invalid Module defintion. No `dirname` property found');
+    if (!this.dirname) {
+      this.dirname = path.dirname(callsite()?.[1]?.getFileName?.()) ??
+        throwError('Invalid module definition. No `dirname` property found');
+    }
     // Extract the name and version from `__dirname`
     const pathSegments = this.dirname.split(path.sep);
     const name = pathSegments[pathSegments.length - 1];

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -393,7 +393,8 @@ export class Module2 {
     this.utils = def?.utils ?? {};
     this.mappers = Object.fromEntries(
       Object.entries(def.mappers)
-        .filter(([_, m]: [string, any]) => m instanceof Mapper2) as [[string, MapperInterface<any>]]
+        .filter(([_, m]: [string, any]) => (m instanceof Mapper2 || m instanceof MapperBase)
+      ) as [[string, MapperInterface<any>]]
     );
     const migrationDir = `${dirname}/migration`;
     const files = fs.readdirSync(migrationDir).filter(f => !/.map$/.test(f));
@@ -485,7 +486,8 @@ export class ModuleBase {
     if (this.context) this.provides.context = this.context;
     this.mappers = Object.fromEntries(
       Object.entries(this)
-        .filter(([_, m]: [string, any]) => m instanceof Mapper2) as [[string, MapperInterface<any>]]
+        .filter(([_, m]: [string, any]) => (m instanceof Mapper2 || m instanceof MapperBase)
+      ) as [[string, MapperInterface<any>]]
     );
     const migrationDir = `${this.dirname}/migration`;
     const files = fs.readdirSync(migrationDir).filter(f => !/.map$/.test(f));

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -20,7 +20,7 @@ import MetadataRepo from './repositories/metadata'
 import config from '../config'
 import { throwError, } from '../config/config'
 import logger, { debugObj } from './logger'
-import { Context, MapperInterface2, ModuleInterface, } from '../modules'
+import { Context, MapperInterface, ModuleInterface, } from '../modules'
 import { DepError, lazyLoader, } from './lazy-dep'
 import { IasqlDatabase, } from '../entity'
 import { TypeormWrapper, } from './typeorm'
@@ -438,13 +438,13 @@ export async function apply(dbId: string, dryRun: boolean, ormOpt?: TypeormWrapp
         const updatePlan = (
           crupde: Crupde,
           entityName: string,
-          mapper: MapperInterface2<any>,
+          mapper: MapperInterface<any>,
           es: any[]
         ) => {
           crupde[entityName] = crupde[entityName] ?? [];
           const rs = es.map((e: any) => ({
             id: e?.id?.toString() ?? '',
-            description: mapper.entityId?.(e) ?? '',
+            description: mapper.entityId(e),
           }));
           rs.forEach(r => {
             if (!crupde[entityName]
@@ -654,13 +654,13 @@ export async function sync(dbId: string, dryRun: boolean, ormOpt?: TypeormWrappe
         const updatePlan = (
           crupde: Crupde,
           entityName: string,
-          mapper: MapperInterface2<any>,
+          mapper: MapperInterface<any>,
           es: any[]
         ) => {
           crupde[entityName] = crupde[entityName] ?? [];
           const rs = es.map((e: any) => ({
             id: e?.id?.toString() ?? '',
-            description: mapper.entityId?.(e) ?? '',
+            description: mapper.entityId(e),
           }));
           rs.forEach(r => {
             if (!crupde[entityName]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2632,6 +2632,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/callsite@^1.0.31":
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/@types/callsite/-/callsite-1.0.31.tgz#55cfc887088d67f0310fcb20bd9100bb7146d2fc"
+  integrity sha512-jrKmIHhuZVGUpOR1s4TgY9BTt/Eh9CFCjHVZ2FsrKmHSo3J/vpl6EpK08SfMLrX2IY1ZEFA+BPRTJQGg4xIHsA==
+
 "@types/connect@*":
   version "3.4.35"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
@@ -3238,6 +3243,11 @@ call-bind@^1.0.0:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+callsite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+  integrity sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==
 
 callsites@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Part of #862. I decided to switch to a simpler module for this first pass, and I made the Mapper also a class, but left the Crud properties mostly alone since there's exactly 1 or 2 of them per mapper, unlike the unknown number of mappers per module.

I attach `this.module` to the Mapper and Crud objects so the methods can get *their instance* of the module by going `this.module.<etc>` and I confirmed it's fully typed by Typescript, so I'm happier with this.

I don't like the `dirname = __dirname` that's required right now, since it's an easy-to-forget line to include, so I added a dependency on `callsite` which let's me get the file information from every line of a stack trace, and use it to find the directory where a module is defined in the new `ModuleBase` base class.