### PR TITLE
Drop explicit dependency declarations

### DIFF
--- a/src/modules/0.0.17/aws_account/index.ts
+++ b/src/modules/0.0.17/aws_account/index.ts
@@ -1,7 +1,6 @@
 import { AWS, } from '../../../services/aws_macros'
 import { AwsAccountEntity, } from './entity'
 import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
-import * as metadata from './module.json' // TODO: Eliminate this?
 
 class AccountMapper extends MapperBase<AwsAccountEntity> {
   module: AwsAccount;
@@ -26,7 +25,6 @@ class AccountMapper extends MapperBase<AwsAccountEntity> {
 }
 
 class AwsAccount extends ModuleBase {
-  dependencies = metadata.dependencies;
   context: Context = {
     // This function is `async function () {` instead of `async () => {` because that enables the
     // `this` keyword within the function based on the objec it is being called from, so the

--- a/src/modules/0.0.17/aws_acm_import/index.ts
+++ b/src/modules/0.0.17/aws_acm_import/index.ts
@@ -3,7 +3,6 @@ import { AWS, paginateBuilder, } from '../../../services/aws_macros'
 import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
 import { awsAcmListModule } from '../aws_acm_list'
 import { CertificateImport } from './entity'
-import * as metadata from './module.json'
 
 class CertificateImportMapper extends MapperBase<CertificateImport> {
   module: AwsAcmImportModule;
@@ -79,7 +78,6 @@ class CertificateImportMapper extends MapperBase<CertificateImport> {
 }
 
 class AwsAcmImportModule extends ModuleBase {
-  dependencies = metadata.dependencies;
   certificateImport: CertificateImportMapper;
 
   constructor() {

--- a/src/modules/0.0.17/aws_acm_list/index.ts
+++ b/src/modules/0.0.17/aws_acm_list/index.ts
@@ -12,7 +12,6 @@ import {
   certificateStatusEnum,
   certificateTypeEnum,
 } from './entity'
-import * as metadata from './module.json'
 
 class CertificateMapper extends MapperBase<Certificate> {
   module: AwsAcmListModule;
@@ -143,7 +142,6 @@ class CertificateMapper extends MapperBase<Certificate> {
 }
 
 class AwsAcmListModule extends ModuleBase {
-  dependencies = metadata.dependencies;
   certificate: CertificateMapper;
 
   constructor() {

--- a/src/modules/0.0.17/aws_cloudwatch/index.ts
+++ b/src/modules/0.0.17/aws_cloudwatch/index.ts
@@ -2,7 +2,6 @@ import { CloudWatchLogs, paginateDescribeLogGroups, } from '@aws-sdk/client-clou
 import { AWS, crudBuilderFormat, paginateBuilder, } from '../../../services/aws_macros'
 import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
 import { LogGroup } from './entity'
-import * as metadata from './module.json'
 
 class LogGroupMapper extends MapperBase<LogGroup> {
   module: AwsCloudwatchModule;
@@ -99,7 +98,6 @@ class LogGroupMapper extends MapperBase<LogGroup> {
 }
 
 class AwsCloudwatchModule extends ModuleBase {
-  dependencies = metadata.dependencies;
   logGroup: LogGroupMapper;
 
   constructor() {

--- a/src/modules/0.0.17/aws_dynamo/index.ts
+++ b/src/modules/0.0.17/aws_dynamo/index.ts
@@ -14,7 +14,6 @@ import pick from 'lodash.pick'
 import { AWS, crudBuilder2, paginateBuilder, } from '../../../services/aws_macros'
 import { DynamoTable, TableClass, } from './entity'
 import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
-import * as metadata from './module.json'
 import { throwError, } from '../../../config/config'
 
 class DynamoTableMapper extends MapperBase<DynamoTable> {
@@ -182,7 +181,6 @@ class DynamoTableMapper extends MapperBase<DynamoTable> {
 }
 
 class AwsDynamoModule extends ModuleBase {
-  dependencies = metadata.dependencies;
   dynamoTable: DynamoTableMapper;
 
   constructor() {

--- a/src/modules/0.0.17/aws_ecr/index.ts
+++ b/src/modules/0.0.17/aws_ecr/index.ts
@@ -13,7 +13,6 @@ import { AWS, crudBuilder2, crudBuilderFormat, paginateBuilder, } from '../../..
 import logger from '../../../services/logger'
 import { PublicRepository, Repository, RepositoryPolicy, ImageTagMutability, } from './entity'
 import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
-import * as metadata from './module.json'
 
 class PublicRepositoryMapper extends MapperBase<PublicRepository> {
   module: AwsEcrModule;
@@ -453,7 +452,6 @@ class RepositoryPolicyMapper extends MapperBase<RepositoryPolicy> {
 }
 
 class AwsEcrModule extends ModuleBase {
-  dependencies = metadata.dependencies; // TODO: Drop this
   publicRepository: PublicRepositoryMapper;
   repository: RepositoryMapper;
   repositoryPolicy: RepositoryPolicyMapper;

--- a/src/modules/0.0.17/aws_elb/index.ts
+++ b/src/modules/0.0.17/aws_elb/index.ts
@@ -37,7 +37,6 @@ import {
 import { AwsVpcModule, } from '../aws_vpc'
 import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
 import { awsAcmListModule, AwsSecurityGroupModule } from '..'
-import * as metadata from './module.json'
 
 class ListenerMapper extends MapperBase<Listener> {
   module: AwsElbModule;
@@ -781,7 +780,6 @@ class TargetGroupMapper extends MapperBase<TargetGroup> {
 }
 
 class AwsElbModule extends ModuleBase {
-  dependencies = metadata.dependencies; // TODO: Delete this
   listener: ListenerMapper;
   loadBalancer: LoadBalancerMapper;
   targetGroup: TargetGroupMapper;

--- a/src/modules/0.0.17/aws_iam/index.ts
+++ b/src/modules/0.0.17/aws_iam/index.ts
@@ -8,7 +8,6 @@ import isEqual from 'lodash.isequal'
 import { Role } from './entity'
 import { AWS, crudBuilder2, crudBuilderFormat, mapLin, paginateBuilder, } from '../../../services/aws_macros'
 import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
-import * as metadata from './module.json'
 
 class RoleMapper extends MapperBase<Role> {
   module: AwsIamModule;
@@ -315,7 +314,6 @@ class RoleMapper extends MapperBase<Role> {
 
 
 class AwsIamModule extends ModuleBase {
-  dependencies = metadata.dependencies; // TODO: Remove this
   role: RoleMapper;
 
   constructor() {

--- a/src/modules/0.0.17/aws_rds/index.ts
+++ b/src/modules/0.0.17/aws_rds/index.ts
@@ -18,7 +18,6 @@ import { AWS, crudBuilder2, crudBuilderFormat, paginateBuilder, mapLin, } from '
 import { ParameterGroup, ParameterGroupFamily, RDS, } from './entity'
 import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
 import { AwsSecurityGroupModule, AwsVpcModule, } from '..'
-import * as metadata from './module.json'
 
 interface DBParameterGroupWParameters extends DBParameterGroup {
   Parameters:  Parameter[];
@@ -533,7 +532,6 @@ class ParameterGroupMapper extends MapperBase<ParameterGroup> {
 }
 
 class AwsRdsModule extends ModuleBase {
-  dependencies = metadata.dependencies;
   rds: RdsMapper;
   parameterGroup: ParameterGroupMapper;
 

--- a/src/modules/0.0.17/aws_s3/index.ts
+++ b/src/modules/0.0.17/aws_s3/index.ts
@@ -8,7 +8,6 @@ import {
 import { AWS, crudBuilder2, crudBuilderFormat, } from '../../../services/aws_macros'
 import { Bucket, } from './entity'
 import { Context, Crud2, MapperBase, ModuleBase, } from '../../interfaces'
-import * as metadata from './module.json'
 import isEqual from 'lodash.isequal'
 
 class BucketMapper extends MapperBase<Bucket> {
@@ -159,7 +158,6 @@ class BucketMapper extends MapperBase<Bucket> {
 }
 
 class AwsS3Module extends ModuleBase {
-  dependencies = metadata.dependencies;
   bucket: BucketMapper;
 
   constructor() {

--- a/src/modules/0.0.17/iasql_functions/index.ts
+++ b/src/modules/0.0.17/iasql_functions/index.ts
@@ -1,12 +1,10 @@
 /* THIS MODULE IS A SPECIAL SNOWFLAKE. DON'T LOOK AT IT FOR HOW TO WRITE A REAL MODULE */
 
-import * as metadata from './module.json'
 import { IasqlOperationType, } from './entity'
 import { ModuleBase, } from '../../interfaces'
 
 class IasqlFunctions extends ModuleBase {
   constructor() { super(); super.init(); }
-  dependencies = metadata.dependencies;
   iasqlOperationType = IasqlOperationType;
 }
 export const iasqlFunctions = new IasqlFunctions();

--- a/src/modules/0.0.17/iasql_platform/index.ts
+++ b/src/modules/0.0.17/iasql_platform/index.ts
@@ -1,12 +1,10 @@
 /* THIS MODULE IS A SPECIAL SNOWFLAKE. DON'T LOOK AT IT FOR HOW TO WRITE A REAL MODULE */
 
 import { ModuleBase, } from '../../interfaces'
-import * as metadata from './module.json'
 import { IasqlModule, IasqlTables, } from './entity'
 
 class IasqlPlatform extends ModuleBase {
   constructor() { super(); super.init(); }
-  dependencies = metadata.dependencies;
   iasqlModule = IasqlModule;
   iasqlTables = IasqlTables;
 }


### PR DESCRIPTION
The new class-based modules don't need to explicitly declare their dependencies anymore, so dropping that from the converted modules.