### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM node:16-bullseye
 WORKDIR /engine/
+
+COPY package.json /engine/package.json
+COPY yarn.lock /engine/yarn.lock
+RUN ["yarn", "install"]
+
+RUN ["apt", "update"]
+RUN ["apt", "upgrade", "-y"]
+RUN ["apt", "install", "postgresql-client-13", "-y"]
+
 COPY . /engine/
 ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
 ARG IASQL_ENV
 ENV IASQL_ENV=$IASQL_ENV
-RUN apt update
-RUN apt upgrade -y
-RUN apt install postgresql-client-13 -y
-RUN yarn
-RUN yarn build
+RUN ["yarn", "build"]
 EXPOSE 8088
 CMD yarn start


### PR DESCRIPTION
Old Dockerfile issues:
- We can make it faster by separating the copy for `package.json` and the codebase
  - https://www.ginkgobioworks.com/2020/05/18/optimizing-your-dockerfile/
  - Should not do `yarn install` again when the `package.json`/`yarn.lock` has not been changed
- Mounting the current directory makes it problematic if the docker container and the host machine’s OS are different(darwin vs linux)
   - The inner container installs the packages and overrides the `node_modules` folder on the host machine, making it problematic when trying to work on the host machine
    - Adding `node_modules` directory to the `.dockerignore` file fixes this