### PR TITLE
Fixed local development bug and ignored unneeded files from docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,9 @@
 .env
 .deploy-env
 iasql-on-iasql.out.sql
-node_modules
-dist
-.github
-docs
-rfcs
+node_modules/
+dist/
+.github/
+docs/
+rfcs/
 *.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
 .env
 .deploy-env
 iasql-on-iasql.out.sql
+node_modules
+dist
+.github
+docs
+rfcs
+*.md


### PR DESCRIPTION
- Ignored the `node_modules` dir. Copying this can cause `ERR_DLOPEN_FAILED` error originating from the libraries, due to the inconsistency between the host platform and Linux (Docker). Ref: https://stackoverflow.com/a/29994851/9466794

![Screen Shot 2022-08-28 at 23 24 28](https://user-images.githubusercontent.com/38781512/187098011-eb96eb05-2d63-4fba-8d6f-afcfb9bf8027.png)


- Also ignored unneeded files like `dist/`, CI and documentation files
