### PR TITLE
Improved logging in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,9 @@ jobs:
         env:
           SECRET_HEADER: ${{ secrets.SECRET_HEADER }}
         run: |
-          ACCOUNT_INDEX=$(curl -X POST -H "Content-Type: text/plain" -H "${SECRET_HEADER}" -d '1' https://fkk3xlyad5tobhmezx4onpvele0zyehu.lambda-url.us-east-2.on.aws/ 2>/dev/null | jq '.[0]' || exit 1)
+          RESPONSE=$(curl -X POST -H "Content-Type: text/plain" -H "${SECRET_HEADER}" -d '1' https://fkk3xlyad5tobhmezx4onpvele0zyehu.lambda-url.us-east-2.on.aws/ 2>/dev/null)
+          echo $RESPONSE
+          ACCOUNT_INDEX=$(echo $RESPONSE | jq '.[0]' || exit 1)
           echo "::set-output name=account_index::$(echo ${ACCOUNT_INDEX})"
 
       - name: Run modules tests


### PR DESCRIPTION
I Improved logging in the CI. As @dfellis confirmed on Friday (26/08/2022), the CI would be aborted given a failure response from the Lambda (because of the `jq` query to which the response is piped). However, there is no way to view the error response from the Lambda (for debugging purposes) without logging into CloudWatch and digging - which could easily take minutes of development time.

I have simply added a way to log the error so we can view it in GH actions directly.