### PR TITLE
Refactor Scheduler functions and add Sentry error logging

### DIFF
--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -103,7 +103,7 @@ export async function connect(dbAlias: string, uid: string, email: string, dbId 
     `);
     // wait for the scheduler to start and register its migrations before ours so that the stored procedures
     // that use the scheduler's schema succeed
-    await scheduler.start(dbId, dbUser);
+    await scheduler.start(dbId);
     schedulerStarted = true;
     conn2 = await createConnection({
       ...dbMan.baseConnConfig,

--- a/src/services/scheduler-api.ts
+++ b/src/services/scheduler-api.ts
@@ -1,7 +1,9 @@
 import { readdirSync } from 'fs';
 import fetch from 'node-fetch';
 
+import { IasqlDatabase } from '../entity';
 import logger from '../services/logger';
+import MetadataRepo from './repositories/metadata';
 import * as scheduler from './scheduler';
 
 const schedulerAddress = 'http://localhost:14527';
@@ -22,8 +24,14 @@ async function fetchOrRaise(url: string) {
 }
 
 export const init = () => (shouldRpc ? fetchOrRaise(`${schedulerAddress}/init/`) : scheduler.init());
-export const start = (dbId: string, dbUser: string) =>
-  shouldRpc ? fetchOrRaise(`${schedulerAddress}/start/${dbId}/${dbUser}/`) : scheduler.start(dbId, dbUser);
-export const stop = (dbId: string) =>
-  shouldRpc ? fetchOrRaise(`${schedulerAddress}/stop/${dbId}/`) : scheduler.stop(dbId);
+export const start = async (dbId: string) => {
+  if (shouldRpc) return fetchOrRaise(`${schedulerAddress}/start/${dbId}/`);
+  const db = (await MetadataRepo.getDbById(dbId)) as IasqlDatabase;
+  return scheduler.start(db);
+};
+export const stop = async (dbId: string) => {
+  if (shouldRpc) return fetchOrRaise(`${schedulerAddress}/stop/${dbId}/`);
+  const db = (await MetadataRepo.getDbById(dbId)) as IasqlDatabase;
+  return scheduler.stop(db);
+};
 export const stopAll = () => (shouldRpc ? fetchOrRaise(`${schedulerAddress}/stopAll/`) : scheduler.stopAll());

--- a/src/services/scheduler-api.ts
+++ b/src/services/scheduler-api.ts
@@ -23,7 +23,7 @@ async function fetchOrRaise(url: string) {
   throw new Error(error);
 }
 
-export const init = () => (shouldRpc ? fetchOrRaise(`${schedulerAddress}/init/`) : scheduler.init());
+export const init = () => (shouldRpc ? Promise.resolve() : scheduler.init()); // no-op when not on test
 export const start = async (dbId: string) => {
   if (shouldRpc) return fetchOrRaise(`${schedulerAddress}/start/${dbId}/`);
   const db = (await MetadataRepo.getDbById(dbId)) as IasqlDatabase;

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -260,9 +260,11 @@ if (require.main === module) {
     res.sendStatus(200);
   });
 
-  app.listen(port, () => {
-    logger.info(`Scheduler running on port ${port}`);
-
-    init().catch(e => respondErrorAndDie(undefined, e));
-  });
+  init()
+    .then(() => {
+      app.listen(port, () => {
+        logger.info(`Scheduler running on port ${port}`);
+      });
+    })
+    .catch(e => respondErrorAndDie(undefined, e));
 }

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -220,8 +220,7 @@ if (require.main === module) {
     } else {
       errorResponse = logErrSentry(err);
     }
-
-    res.status(500).send(errorResponse);
+    if (res) res.status(500).send(errorResponse);
     logger.error(`Scheduler exited with error: ${err}`);
     process.exit(13);
   }
@@ -229,12 +228,6 @@ if (require.main === module) {
   app.use((req: any, res: any, next: any) => {
     logger.info(`Scheduler called on ${req.url}`);
     next();
-  });
-
-  app.get('/init/', (req: any, res: any) => {
-    init()
-      .then(() => res.sendStatus(200))
-      .catch(e => respondErrorAndDie(res, e));
   });
 
   app.get('/start/:dbId/', async (req: any, res: any) => {
@@ -269,5 +262,7 @@ if (require.main === module) {
 
   app.listen(port, () => {
     logger.info(`Scheduler running on port ${port}`);
+
+    init().catch(e => respondErrorAndDie(undefined, e));
   });
 }

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -25,7 +25,8 @@ const workerRunners: { [key: string]: { runner: any; conn: any } } = {}; // TODO
 // graphile-worker here functions as a library, not a child process.
 // It manages its own database schema
 // (graphile_worker) and migrations in each uid db using our credentials
-export async function start(dbId: string, dbUser: string) {
+export async function start(db: IasqlDatabase) {
+  const { pgName: dbId, pgUser: dbUser } = db;
   // use the same connection for the scheduler and its operations
   const conn = await TypeormWrapper.createConn(dbId, { name: uuidv4() });
   // create a dblink server per db to reduce connections when calling dblink in iasql op SP
@@ -87,10 +88,10 @@ export async function start(dbId: string, dbUser: string) {
         }
         let output;
         let error;
-        const user = await MetadataRepo.getUserFromDbId(dbId);
+        const user = db?.iasqlUsers?.[0];
         const uid = user?.id;
         const email = user?.email;
-        const dbAlias = user?.iasqlDatabases?.[0]?.alias;
+        const dbAlias = db?.alias;
         try {
           output = await promise;
           // once the operation completes updating the `end_date`
@@ -150,12 +151,15 @@ export async function start(dbId: string, dbUser: string) {
   workerRunners[dbId] = { runner, conn };
 }
 
-export async function stop(dbId: string) {
+export async function stop(db: IasqlDatabase) {
+  const dbId = db.pgName;
   const { runner, conn } = workerRunners[dbId] ?? { runner: undefined, conn: undefined };
   if (runner && conn) {
     try {
       await runner.stop();
     } catch (e) {
+      const user = db.iasqlUsers?.[0];
+      logErrSentry(e, user?.id, user?.email, db.alias);
       logger.warn(
         `Graphile workers for ${dbId} has already been stopped. Perhaps Kubernetes is going to restart the process?`,
         { e },
@@ -172,7 +176,7 @@ export async function stop(dbId: string) {
 export async function stopAll() {
   const dbs: IasqlDatabase[] = await MetadataRepo.getAllDbs();
   for (const db of dbs) {
-    await stop(db.pgName);
+    await stop(db);
   }
 }
 
@@ -192,7 +196,7 @@ export async function init() {
       }),
     )
   ).filter((db: IasqlDatabase | undefined) => db !== undefined) as IasqlDatabase[]; // Typescript should know better
-  const inits = await Promise.allSettled(dbs.map(db => start(db.pgName, db.pgUser)));
+  const inits = await Promise.allSettled(dbs.map(db => start(db)));
   for (const [i, bootstrap] of inits.entries()) {
     if (bootstrap.status === 'rejected') {
       const db = dbs[i];
@@ -208,8 +212,16 @@ if (require.main === module) {
   const app = express();
   const port = 14527;
 
-  function respondErrorAndDie(res: any, err: any) {
-    res.status(500).send(err);
+  function respondErrorAndDie(res: any, err: any, db?: IasqlDatabase) {
+    let errorResponse;
+    if (db) {
+      const user = db.iasqlUsers?.[0];
+      errorResponse = logErrSentry(err, user?.id, user?.email, db.alias);
+    } else {
+      errorResponse = logErrSentry(err);
+    }
+
+    res.status(500).send(errorResponse);
     logger.error(`Scheduler exited with error: ${err}`);
     process.exit(13);
   }
@@ -222,27 +234,33 @@ if (require.main === module) {
   app.get('/init/', (req: any, res: any) => {
     init()
       .then(() => res.sendStatus(200))
-      .catch(e => respondErrorAndDie(res, e.message));
+      .catch(e => respondErrorAndDie(res, e));
   });
 
-  app.get('/start/:dbId/:dbUser/', (req: any, res: any) => {
-    const { dbId, dbUser } = req.params;
-    start(dbId, dbUser)
-      .then(() => res.sendStatus(200))
-      .catch(e => respondErrorAndDie(res, e.message));
-  });
-
-  app.get('/stop/:dbId/', (req: any, res: any) => {
+  app.get('/start/:dbId/', async (req: any, res: any) => {
     const { dbId } = req.params;
-    stop(dbId)
+    const db = await MetadataRepo.getDbById(dbId);
+    if (!db) return respondErrorAndDie(res, new Error('dbId not found!'));
+
+    start(db)
       .then(() => res.sendStatus(200))
-      .catch(e => respondErrorAndDie(res, e.message));
+      .catch(e => respondErrorAndDie(res, e, db));
+  });
+
+  app.get('/stop/:dbId/', async (req: any, res: any) => {
+    const { dbId } = req.params;
+    const db = await MetadataRepo.getDbById(dbId);
+    if (!db) return respondErrorAndDie(res, new Error('dbId not found!'));
+
+    stop(db)
+      .then(() => res.sendStatus(200))
+      .catch(e => respondErrorAndDie(res, e, db));
   });
 
   app.get('/stopAll/', (req: any, res: any) => {
     stopAll()
       .then(() => res.sendStatus(200))
-      .catch(e => respondErrorAndDie(res, e.message));
+      .catch(e => respondErrorAndDie(res, e));
   });
 
   app.head('/health/', (req: any, res: any) => {


### PR DESCRIPTION
I didn't find a reason for why we were passing both the `dbId` and the `dbUser` variables to the Scheduler, so I just removed `dbUser` 😄 .