### PR TITLE
fix: use an available node type for elasticache update test

### DIFF
--- a/src/modules/0.0.19/aws_elasticache/index.ts
+++ b/src/modules/0.0.19/aws_elasticache/index.ts
@@ -39,7 +39,7 @@ class CacheClusterMapper extends MapperBase<CacheCluster> {
       {
         client,
         // all in seconds
-        maxWaitTime: 3000,
+        maxWaitTime: 1200,
         minDelay: 1,
         maxDelay: 4,
       },

--- a/src/modules/0.0.19/aws_elasticache/index.ts
+++ b/src/modules/0.0.19/aws_elasticache/index.ts
@@ -39,7 +39,7 @@ class CacheClusterMapper extends MapperBase<CacheCluster> {
       {
         client,
         // all in seconds
-        maxWaitTime: 300,
+        maxWaitTime: 3000,
         minDelay: 1,
         maxDelay: 4,
       },

--- a/test/modules/aws-elasticache-integration.ts
+++ b/test/modules/aws-elasticache-integration.ts
@@ -136,11 +136,10 @@ describe('Elasticache Integration Testing', () => {
   SELECT * FROM cache_cluster WHERE cluster_id='${clusterId}' AND node_type='${updatedNodeType}';
 `,
       (res: any) => expect(res.length).toBe(1),
-    ),
-      (e?: any) => {
-        if (!!e) return done(e);
-        done();
-      };
+    )((e?: any) => {
+      if (!!e) return done(e);
+      done();
+    });
   });
 
   it(

--- a/test/modules/aws-elasticache-integration.ts
+++ b/test/modules/aws-elasticache-integration.ts
@@ -39,14 +39,12 @@ const elasticacheclient = new ElastiCache({
 });
 
 const getAvailableNodeTypes = async () => {
-  const reservations = await elasticacheclient.describeReservedCacheNodesOfferings({
-    OfferingType: 'Light Utilization',
-  });
+  const reservations = await elasticacheclient.describeReservedCacheNodesOfferings({});
   if (reservations && reservations.ReservedCacheNodesOfferings) {
     const items: string[] = [];
-    // iterate over list and get the ones matching the product description
+    // iterate over list and get the ones matching the product description, and small size
     reservations.ReservedCacheNodesOfferings.forEach(function (node) {
-      if (node.ProductDescription == cacheType) {
+      if (node.ProductDescription == cacheType && node.CacheNodeType?.includes('small')) {
         if (node.CacheNodeType) items.push(node.CacheNodeType);
       }
     });

--- a/test/modules/aws-elasticache-integration.ts
+++ b/test/modules/aws-elasticache-integration.ts
@@ -39,7 +39,9 @@ const elasticacheclient = new ElastiCache({
 });
 
 const getAvailableNodeTypes = async () => {
-  const reservations = await elasticacheclient.describeReservedCacheNodesOfferings({});
+  const reservations = await elasticacheclient.describeReservedCacheNodesOfferings({
+    OfferingType: 'Light Utilization',
+  });
   if (reservations && reservations.ReservedCacheNodesOfferings) {
     const items: string[] = [];
     // iterate over list and get the ones matching the product description

--- a/test/modules/aws-elasticache-integration.ts
+++ b/test/modules/aws-elasticache-integration.ts
@@ -131,7 +131,7 @@ describe('Elasticache Integration Testing', () => {
     'checks that cache_cluster have been modified',
     query(
       `
-  SELECT * FROM cache_cluster WHERE node_type='${updatedNodeType}';
+  SELECT * FROM cache_cluster WHERE cluster_id='${clusterId}' AND node_type='${updatedNodeType}';
 `,
       (res: any) => expect(res.length).toBe(1),
     ),
@@ -146,15 +146,18 @@ describe('Elasticache Integration Testing', () => {
 
   it('applies the cache_cluster engine update', apply());
 
-  it(
-    'checks that cache_cluster engine has not been modified',
+  it('checks that cache_cluster engine has not been modified', done => {
     query(
       `
   SELECT * FROM cache_cluster WHERE cluster_id='${clusterId}' AND engine='${cacheType}';
 `,
       (res: any) => expect(res.length).toBe(1),
     ),
-  );
+      (e?: any) => {
+        if (!!e) return done(e);
+        done();
+      };
+  });
 
   it(
     'checks that cache_cluster with new engine does not exist',

--- a/test/modules/aws-elasticache-integration.ts
+++ b/test/modules/aws-elasticache-integration.ts
@@ -46,7 +46,7 @@ const getAvailableNodeTypes = async () => {
     reservations.ReservedCacheNodesOfferings.forEach(function (node) {
       if (
         node.ProductDescription == cacheType &&
-        (node.CacheNodeType?.includes('small') || node.CacheNodeType?.includes('micro'))
+        (node.CacheNodeType?.includes('small') || node.CacheNodeType?.includes('medium'))
       ) {
         if (node.CacheNodeType) items.push(node.CacheNodeType);
       }
@@ -57,14 +57,13 @@ const getAvailableNodeTypes = async () => {
 };
 let nodeType: string, updatedNodeType: string;
 
-jest.setTimeout(620000);
+jest.setTimeout(1240000);
 beforeAll(async () => {
-  // just sleep
   const nodes = await getAvailableNodeTypes();
   nodeType = nodes.pop() ?? '';
   updatedNodeType = nodes.pop() ?? '';
   await execComposeUp();
-}, 60000);
+});
 afterAll(async () => await execComposeDown());
 
 describe('Elasticache Integration Testing', () => {


### PR DESCRIPTION
Not all node types are available to be used on elasticache,
and they need to be taken from an api. While the test was using
this workflow for creating the cache, it was not using it
for updating it.
Modify the tests to pick a valid node as well for that test.

Signed-off-by: Yolanda Robla <info@ysoft.biz>