### PR TITLE
Upgrade Postgres to 14.4

### DIFF
--- a/.module_migration.sh
+++ b/.module_migration.sh
@@ -16,7 +16,7 @@ docker volume prune -f
 docker image prune -f
 
 # Start a postgres container
-docker container run -p 5432:5432 -e POSTGRES_PASSWORD=test --name migrate-postgres -d postgres:13.4
+docker container run -p 5432:5432 -e POSTGRES_PASSWORD=test --name migrate-postgres -d postgres:14.4
 
 sleep 5 # Just in case
 psql postgresql://postgres:test@localhost:5432/postgres -c "CREATE DATABASE __example__"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ COPY yarn.lock /engine/yarn.lock
 RUN ["yarn", "install"]
 
 RUN ["apt", "update"]
-RUN ["apt", "install", "curl", "ca-certificates", "gnupg"]
-RUN ["echo", "'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/postgresql.list"]
+RUN ["apt", "install", "curl", "ca-certificates", "gnupg", "-y"]
+RUN ["bash", "-c", "curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null"]
+RUN ["bash", "-c", "echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/postgresql.list"]
 RUN ["apt", "update"]
 RUN ["apt", "upgrade", "-y"]
 RUN ["apt", "install", "postgresql-client-14", "-y"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN ["yarn", "install"]
 
 RUN ["apt", "update"]
 RUN ["apt", "upgrade", "-y"]
-RUN ["apt", "install", "postgresql-client-13", "-y"]
+RUN ["apt", "install", "postgresql-client-14", "-y"]
 
 COPY . /engine/
 ARG SENTRY_RELEASE

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY yarn.lock /engine/yarn.lock
 RUN ["yarn", "install"]
 
 RUN ["apt", "update"]
+RUN ["apt", "install", "curl", "ca-certificates", "gnupg"]
+RUN ["echo", "'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/postgresql.list"]
+RUN ["apt", "update"]
 RUN ["apt", "upgrade", "-y"]
 RUN ["apt", "install", "postgresql-client-14", "-y"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     links:
       - postgresql
   postgresql:
-    image: postgres:13.4
+    image: postgres:14.4
     ports:
       - "5432:5432"
     environment:

--- a/docs/docs/sample-queries/aws_rds.md
+++ b/docs/docs/sample-queries/aws_rds.md
@@ -17,7 +17,7 @@ Create a DB instance in the [rds](https://dbdocs.io/iasql/iasql?table=rds&schema
 
 ```sql
 INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-  VALUES ('iasqlsample', 20, 'db.t3.micro', 'test', 'testpass', (select * from availability_zone limit 1), 'postgres:13.4', 0);
+  VALUES ('iasqlsample', 20, 'db.t3.micro', 'test', 'testpass', (select * from availability_zone limit 1), 'postgres:14.4', 0);
 
 INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
   (SELECT id FROM rds WHERE db_instance_identifier='iasqlsample'),
@@ -29,7 +29,7 @@ SELECT * FROM iasql_apply();
 <!--- https://www.urlencoder.org/ -->
 <button
   className={"button button--primary button--lg margin-bottom--lg"}
-  onClick={() => window.open('https://app.iasql.com/#/button/INSERT%20INTO%20rds%20%28db_instance_identifier%2C%20allocated_storage%2C%20db_instance_class%2C%20master_username%2C%20master_user_password%2C%20availability_zone%2C%20engine%2C%20backup_retention_period%29%0A%20%20VALUES%20%28%27iasqlsample%27%2C%2020%2C%20%27db.t3.micro%27%2C%20%27test%27%2C%20%27testpass%27%2C%20%28select%20%2A%20from%20availability_zone%20limit%201%29%2C%20%27postgres%3A13.4%27%2C%200%29%3B%0A%0AINSERT%20INTO%20rds_security_groups%20%28rds_id%2C%20security_group_id%29%20SELECT%0A%20%20%28SELECT%20id%20FROM%20rds%20WHERE%20db_instance_identifier%3D%27iasqlsample%27%29%2C%0A%20%20%28SELECT%20id%20FROM%20security_group%20WHERE%20group_name%3D%27default%27%29%3B%0A%0ASELECT%20%2A%20FROM%20iasql_preview_apply%28%29%3B', '_blank')}
+  onClick={() => window.open('https://app.iasql.com/#/button/INSERT%20INTO%20rds%20%28db_instance_identifier%2C%20allocated_storage%2C%20db_instance_class%2C%20master_username%2C%20master_user_password%2C%20availability_zone%2C%20engine%2C%20backup_retention_period%29%0A%20%20VALUES%20%28%27iasqlsample%27%2C%2020%2C%20%27db.t3.micro%27%2C%20%27test%27%2C%20%27testpass%27%2C%20%28select%20%2A%20from%20availability_zone%20limit%201%29%2C%20%27postgres%3A14.4%27%2C%200%29%3B%0A%0AINSERT%20INTO%20rds_security_groups%20%28rds_id%2C%20security_group_id%29%20SELECT%0A%20%20%28SELECT%20id%20FROM%20rds%20WHERE%20db_instance_identifier%3D%27iasqlsample%27%29%2C%0A%20%20%28SELECT%20id%20FROM%20security_group%20WHERE%20group_name%3D%27default%27%29%3B%0A%0ASELECT%20%2A%20FROM%20iasql_preview_apply%28%29%3B', '_blank')}
 >
 Run SQL
 </button>

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgresql:
-    image: postgres:13.4
+    image: postgres:14.4
     ports:
       - "5432:5432"
     environment:

--- a/test/modules/aws-rds-integration.ts
+++ b/test/modules/aws-rds-integration.ts
@@ -36,7 +36,7 @@ describe('RDS Integration Testing', () => {
   it('creates an RDS instance', query(`
     BEGIN;
       INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:13.4', 0);
+        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.4', 0);
       INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
         (SELECT id FROM rds WHERE db_instance_identifier='${prefix}test'),
         (SELECT id FROM security_group WHERE group_name='default');
@@ -61,7 +61,7 @@ describe('RDS Integration Testing', () => {
   it('creates an RDS instance', query(`
     BEGIN;
       INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:13.4', 0);
+        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.4', 0);
       INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
         (SELECT id FROM rds WHERE db_instance_identifier='${prefix}test'),
         (SELECT id FROM security_group WHERE group_name='default');

--- a/test/modules/aws-rds-integration.ts
+++ b/test/modules/aws-rds-integration.ts
@@ -36,7 +36,7 @@ describe('RDS Integration Testing', () => {
   it('creates an RDS instance', query(`
     BEGIN;
       INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.4', 0);
+        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.0', 0);
       INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
         (SELECT id FROM rds WHERE db_instance_identifier='${prefix}test'),
         (SELECT id FROM security_group WHERE group_name='default');
@@ -61,7 +61,7 @@ describe('RDS Integration Testing', () => {
   it('creates an RDS instance', query(`
     BEGIN;
       INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.4', 0);
+        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.0', 0);
       INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
         (SELECT id FROM rds WHERE db_instance_identifier='${prefix}test'),
         (SELECT id FROM security_group WHERE group_name='default');
@@ -84,7 +84,7 @@ describe('RDS Integration Testing', () => {
   `, (res: any[]) => expect(res.length).toBe(1)));
 
   it('changes the postgres version', query(`
-    UPDATE rds SET engine = 'postgres:13.5' WHERE db_instance_identifier = '${prefix}test';
+    UPDATE rds SET engine = 'postgres:14.4' WHERE db_instance_identifier = '${prefix}test';
   `));
 
   it('applies the change', apply());

--- a/test/modules/aws-rds-integration.ts
+++ b/test/modules/aws-rds-integration.ts
@@ -36,7 +36,7 @@ describe('RDS Integration Testing', () => {
   it('creates an RDS instance', query(`
     BEGIN;
       INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.0', 0);
+        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.1', 0);
       INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
         (SELECT id FROM rds WHERE db_instance_identifier='${prefix}test'),
         (SELECT id FROM security_group WHERE group_name='default');
@@ -61,7 +61,7 @@ describe('RDS Integration Testing', () => {
   it('creates an RDS instance', query(`
     BEGIN;
       INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.0', 0);
+        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', '${availabilityZone}', 'postgres:14.1', 0);
       INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
         (SELECT id FROM rds WHERE db_instance_identifier='${prefix}test'),
         (SELECT id FROM security_group WHERE group_name='default');


### PR DESCRIPTION
This PR is to test whether or not things break moving to Postgres 14. It is expected to be a drop-in replacement, but we'll soon see.