### PR TITLE
Several fixes to issues encountered during 0.0.19 deployment attempt

### DIFF
--- a/.develop.sh
+++ b/.develop.sh
@@ -24,6 +24,9 @@ CONFIGSTAGING="$(cat src/config/staging.ts | sed "s/latestVersion:.*/latestVersi
 CONFIGTEST="$(cat src/config/test.ts | sed "s/latestVersion:.*/latestVersion: '${VERSION}',/;s/oldestVersion:.*/oldestVersion: '${LASTVERSION}'/")" && echo "${CONFIGTEST}" > src/config/test.ts
 CONFIGBOOTSTRAP="$(cat src/config/bootstrap.ts | sed "s/latestVersion:.*/latestVersion: '${LATESTVERSION}',/;s/oldestVersion:.*/oldestVersion: '${LASTVERSION}'/")" && echo "${CONFIGBOOTSTRAP}" > src/config/bootstrap.ts
 
+# Make sure it's all formatted the way we want it
+yarn format
+
 # Copy the version and push to main
 cp -r src/modules/${LATESTVERSION} src/modules/${VERSION}
 git add src/modules/${VERSION}

--- a/.drop.sh
+++ b/.drop.sh
@@ -27,6 +27,9 @@ CONFIGSTAGING="$(cat src/config/staging.ts | sed "s/latestVersion:.*/latestVersi
 CONFIGTEST="$(cat src/config/test.ts | sed "s/latestVersion:.*/latestVersion: '${VERSION}',/;s/oldestVersion:.*/oldestVersion: '${LASTVERSION}'/")" && echo "${CONFIGTEST}" > src/config/test.ts
 CONFIGBOOTSTRAP="$(cat src/config/bootstrap.ts | sed "s/oldestVersion:.*/oldestVersion: '${LASTVERSION}'/")" && echo "${CONFIGBOOTSTRAP}" > src/config/bootstrap.ts # Bootstrap doesn't get the latest version edited
 
+# Make sure it's all formatted the way we want it
+yarn format
+
 # Drop the version and push to main
 git add src/config/*.ts
 git commit -m "Drop version ${OLDESTVERSION}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,29 @@ jobs:
           A0_IASQL_API_TOKEN: ${{ secrets.A0_IASQL_API_TOKEN }}
           AWS_REGION: us-east-1
 
+  upgrade-test:
+    runs-on: ubuntu-latest
+    name: iasql_upgrade test
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run common tests
+        run: ./test/upgrade/run-upgrade.sh
+        env:
+          IASQL_ENV: test
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_TESTING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_TESTING }}
+          A0_IASQL_API_TOKEN: ${{ secrets.A0_IASQL_API_TOKEN }}
+          AWS_REGION: us-east-1
+
   setup-module-test:
     runs-on: ubuntu-latest
     outputs:

--- a/.version.sh
+++ b/.version.sh
@@ -34,6 +34,9 @@ CONFIGBOOTSTRAP="$(cat src/config/bootstrap.ts | sed "s/latestVersion:.*/latestV
 # Make sure the lockfiles are updated, too
 yarn
 
+# Make sure it's all formatted the way we want it
+yarn format
+
 # Commit and tag the update
 git add package.json yarn.lock src/config/*.ts
 git commit -m "v${VERSION}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-yarn forever start dist/services/scheduler.js
+yarn forever -f dist/services/scheduler.js &
 yarn wait-on http://localhost:14527/health/
 yarn start

--- a/src/config/bootstrap.ts
+++ b/src/config/bootstrap.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.19',
-    oldestVersion: '0.0.16'
+    oldestVersion: '0.0.16',
   },
   db: {
     host: 'db-bootstrap.iasql.com',

--- a/src/config/ci.ts
+++ b/src/config/ci.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.20',
-    oldestVersion: '0.0.16'
+    oldestVersion: '0.0.16',
   },
   db: {
     host: 'postgresql',

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.20',
-    oldestVersion: '0.0.16'
+    oldestVersion: '0.0.16',
   },
   db: {
     host: 'postgresql',

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.19',
-    oldestVersion: '0.0.16'
+    oldestVersion: '0.0.16',
   },
   db: {
     host: 'db.iasql.com',

--- a/src/config/staging.ts
+++ b/src/config/staging.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.20',
-    oldestVersion: '0.0.16'
+    oldestVersion: '0.0.16',
   },
   db: {
     host: 'db-staging.iasql.com',

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -6,7 +6,7 @@ const config: ConfigInterface = {
   },
   modules: {
     latestVersion: '0.0.20',
-    oldestVersion: '0.0.16'
+    oldestVersion: '0.0.16',
   },
   db: {
     host: 'localhost',

--- a/src/modules/0.0.20/aws_account/sql/create_triggers.sql
+++ b/src/modules/0.0.20/aws_account/sql/create_triggers.sql
@@ -3,8 +3,9 @@ RETURNS TEXT LANGUAGE plpgsql AS $$
 DECLARE
   r TEXT;
 BEGIN
-  SELECT CASE WHEN region is NULL THEN 'us-east-1' ELSE region END INTO r
+  SELECT region INTO r
   FROM aws_regions WHERE is_default = TRUE;
+  SELECT CASE WHEN r is NULL THEN 'us-east-1' ELSE r END into r;
   RETURN r;
 END
 $$;

--- a/src/services/iasql.ts
+++ b/src/services/iasql.ts
@@ -1297,7 +1297,7 @@ export async function upgrade(dbId: string, dbUser: string) {
             INSERT INTO aws_credentials (access_key_id, secret_access_key)
             VALUES ('${creds.access_key_id}', '${creds.secret_access_key}');
           `);
-          await sync(dbId, false);
+          await sync(dbId, false, true);
           if (creds.region) {
             await conn.query(`
               UPDATE aws_regions SET is_default = true WHERE region = '${creds.region}';

--- a/test/modules/aws-account-integration.ts
+++ b/test/modules/aws-account-integration.ts
@@ -170,6 +170,24 @@ describe('AwsAccount Integration Testing', () => {
     expect(res[0].default_aws_region).toBe('us-east-1');
   }));
 
+  it('clears out the default region', query(`
+    UPDATE aws_regions SET is_default = false;
+  `));
+
+  it('confirms the `default_aws_region` still returns a default region', query(`
+    SELECT * FROM default_aws_region();
+  `, (res: any[]) => {
+    expect(res.length).toBe(1);
+    expect(res[0].default_aws_region).toBe('us-east-1');
+  }));
+
+  it('updates the default region again', query(`
+    SELECT * FROM default_aws_region('us-east-1');
+  `, (res: any[]) => {
+    expect(res.length).toBe(1);
+    expect(res[0].default_aws_region).toBe('us-east-1');
+  }));
+
   // tests that on startup subsequent iasql ops for existing dbs succeed
   it('stops the worker for all dbs', (done) => void scheduler
     .stopAll()

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -14,6 +14,9 @@ LATESTVERSION=`./node_modules/.bin/ts-node src/scripts/latestVersion.ts`
 OLDESTVERSION=`./node_modules/.bin/ts-node src/scripts/oldestVersion.ts`
 CURRENTGITSHA=`git rev-parse HEAD`
 
+# Github Actions apparently doesn't pull down the tags by default?
+git pull origin --tags
+
 # Check out the older version of the codebase and launch the engine with a local postgres
 git checkout v${OLDESTVERSION}
 yarn docker-compose

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -32,7 +32,7 @@ psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "
 
 # Determine which kind of 'aws_account' module this is (TODO: Remove this branch once v0.0.19 is oldest)
 AWSACCOUNTTABLE=`psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -AXqtc "
-  SELECT table FROM iasql_tables WHERE table = 'aws_account';
+  SELECT "table" FROM iasql_tables WHERE "table" = 'aws_account';
 "`
 if [ "${AWSACCOUNTTABLE}" == "aws_account" ]; then # It's the old style
   psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -9,6 +9,9 @@ if [ ! -f "${PWD}/docker-compose.yml" ]; then
   exit 1;
 fi
 
+# Install the node deps so the following scripts will run
+yarn
+
 # Get metadata on the current branch to use during the test
 LATESTVERSION=`ts-node src/scripts/latestVersion.ts`
 OLDESTVERSION=`ts-node src/scripts/oldestVersion.ts`

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Be 'vex'ing in the output volume
+set -vex
+
+# Make sure the test will work at all
+if [ ! -f "${PWD}/docker-compose.yml" ]; then
+  echo "Must be run from repo root";
+  exit 1;
+fi
+
+# Get metadata on the current branch to use during the test
+LATESTVERSION=`ts-node src/scripts/latestVersion.ts`
+OLDESTVERSION=`ts-node src/scripts/oldestVersion.ts`
+CURRENTGITSHA=`git rev-parse HEAD`
+
+# Check out the older version of the codebase and launch the engine with a local postgres
+git checkout v${OLDESTVERSION}
+yarn docker-compose
+yarn wait-on http://localhost:8088/health/
+
+# Create a new database connected to a test account
+curl http://localhost:8088/v1/db/connect/to_upgrade
+psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "
+  select iasql_install(
+    'aws_account'
+  );
+";
+psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "
+  INSERT INTO aws_credentials (access_key_id, secret_access_key)
+  VALUES ('${AWS_ACCESS_KEY_ID}', '${AWS_SECRET_ACCESS_KEY}');
+";
+psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "
+  SELECT * FROM iasql_sync();
+";
+psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "
+  SELECT * FROM default_aws_region('us-east-1');
+";
+
+# Shut down the database and engine, switch back to the current commit, and fire up a new engine
+docker container stop $(basename ${PWD})_change_engine_1
+docker container stop $(basename ${PWD})_postgresql_1
+git checkout ${CURRENTGITSHA}
+yarn docker-compose
+
+# Actually trigger the upgrade and loop until upgraded (or fail)
+psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "
+  SELECT * FROM iasql_upgrade();
+";
+UPGRADECHECKCOUNT=30
+ISUPGRADED=false
+while [ ${UPGRADECHECKCOUNT} -gt 0 ]; do
+  AWSACCOUNTMODULE=`psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -AXqtc "
+    SELECT name FROM iasql_module WHERE name like 'aws_account*'
+  "`
+  if [ "${AWSACCOUNTMODULE}" == "aws_account@${LATESTVERSION}" ]; then
+    ISUPGRADED=true
+    UPGRADECHECKCOUNT=0
+  fi
+done
+
+# The actual check!
+if [ "${ISUPGRADED}" == "false" ]; then
+  echo "Did not successfully upgrade!";
+  exit 2;
+else
+  echo "Successfully upgraded!";
+fi

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -15,7 +15,7 @@ OLDESTVERSION=`./node_modules/.bin/ts-node src/scripts/oldestVersion.ts`
 CURRENTGITSHA=`git rev-parse HEAD`
 
 # Github Actions apparently doesn't pull down the tags by default?
-git pull origin --tags
+git pull origin --tags ${CURRENTGITSHA}
 
 # Check out the older version of the codebase and launch the engine with a local postgres
 git checkout v${OLDESTVERSION}

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -32,7 +32,7 @@ psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "
 
 # Determine which kind of 'aws_account' module this is (TODO: Remove this branch once v0.0.19 is oldest)
 AWSACCOUNTTABLE=`psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -AXqtc "
-  SELECT "table" FROM iasql_tables WHERE "table" = 'aws_account';
+  SELECT \"table\" FROM iasql_tables WHERE \"table\" = 'aws_account';
 "`
 if [ "${AWSACCOUNTTABLE}" == "aws_account" ]; then # It's the old style
   psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -19,7 +19,7 @@ git pull origin --tags ${CURRENTGITSHA}
 
 # Check out the older version of the codebase and launch the engine with a local postgres
 git checkout v${OLDESTVERSION}
-yarn docker-compose
+yarn docker-compose &
 yarn wait-on http://localhost:8088/health/
 
 # Create a new database connected to a test account
@@ -44,7 +44,7 @@ psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "
 docker container stop $(basename ${PWD})_change_engine_1
 docker container stop $(basename ${PWD})_postgresql_1
 git checkout ${CURRENTGITSHA}
-yarn docker-compose
+yarn docker-compose &
 
 # Actually trigger the upgrade and loop until upgraded (or fail)
 psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -56,10 +56,13 @@ while [ ${UPGRADECHECKCOUNT} -gt 0 ]; do
   AWSACCOUNTMODULE=`psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -AXqtc "
     SELECT name FROM iasql_module WHERE name like 'aws_account*'
   "`
+  echo ${AWSACCOUNTMODULE}; # For debugging purposes
   if [ "${AWSACCOUNTMODULE}" == "aws_account@${LATESTVERSION}" ]; then
     ISUPGRADED=true
     UPGRADECHECKCOUNT=0
   fi
+  sleep 1;
+  UPGRADECHECKCOUNT=$((${UPGRADECHECKCOUNT}-1))
 done
 
 # The actual check!

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -57,6 +57,7 @@ docker container stop $(basename ${PWD})_change_engine_1
 docker container stop $(basename ${PWD})_postgresql_1
 git checkout ${CURRENTGITSHA}
 yarn docker-compose &
+yarn wait-on http://localhost:8088/health/
 
 # Actually trigger the upgrade and loop until upgraded (or fail)
 psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -c "

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -67,7 +67,7 @@ UPGRADECHECKCOUNT=30
 ISUPGRADED=false
 while [ ${UPGRADECHECKCOUNT} -gt 0 ]; do
   AWSACCOUNTMODULE=`psql postgres://postgres:test@127.0.0.1:5432/to_upgrade -AXqtc "
-    SELECT name FROM iasql_module WHERE name like 'aws_account*'
+    SELECT name FROM iasql_module WHERE name like 'aws_account%'
   "`
   echo ${AWSACCOUNTMODULE}; # For debugging purposes
   if [ "${AWSACCOUNTMODULE}" == "aws_account@${LATESTVERSION}" ]; then

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -10,8 +10,8 @@ if [ ! -f "${PWD}/docker-compose.yml" ]; then
 fi
 
 # Get metadata on the current branch to use during the test
-LATESTVERSION=`yarn ts-node src/scripts/latestVersion.ts`
-OLDESTVERSION=`yarn ts-node src/scripts/oldestVersion.ts`
+LATESTVERSION=`./node_modules/.bin/ts-node src/scripts/latestVersion.ts`
+OLDESTVERSION=`./node_modules/.bin/ts-node src/scripts/oldestVersion.ts`
 CURRENTGITSHA=`git rev-parse HEAD`
 
 # Check out the older version of the codebase and launch the engine with a local postgres

--- a/test/upgrade/run-upgrade.sh
+++ b/test/upgrade/run-upgrade.sh
@@ -9,12 +9,9 @@ if [ ! -f "${PWD}/docker-compose.yml" ]; then
   exit 1;
 fi
 
-# Install the node deps so the following scripts will run
-yarn
-
 # Get metadata on the current branch to use during the test
-LATESTVERSION=`ts-node src/scripts/latestVersion.ts`
-OLDESTVERSION=`ts-node src/scripts/oldestVersion.ts`
+LATESTVERSION=`yarn ts-node src/scripts/latestVersion.ts`
+OLDESTVERSION=`yarn ts-node src/scripts/oldestVersion.ts`
 CURRENTGITSHA=`git rev-parse HEAD`
 
 # Check out the older version of the codebase and launch the engine with a local postgres


### PR DESCRIPTION
The issues fixed:

- `docker-entrypoint.sh` now shows the stdout of the scheduler process for better debugging needs
- `iasql_upgrade` no longer barfs on the `sync` call which left the DB half-upgraded
- `default_aws_region` no longer returns NULL if there are no `aws_regions` records with `is_default = true`

Confirmed with manual testing that was then turned into new unit/integration tests.