### PR TITLE
Leave the regions alone!

### DIFF
--- a/src/modules/0.0.20/iasql_functions/sql/create_fns.sql
+++ b/src/modules/0.0.20/iasql_functions/sql/create_fns.sql
@@ -342,7 +342,7 @@ DECLARE
   tables_array text[];
   aux_tables_array text[];
 BEGIN
-  SELECT ARRAY(SELECT "table" FROM iasql_tables WHERE "table" != 'aws_credentials') INTO tables_array;
+  SELECT ARRAY(SELECT "table" FROM iasql_tables WHERE "table" != 'aws_credentials' AND "table" != 'aws_regions') INTO tables_array;
   SELECT array_length(tables_array, 1) INTO tables_array_length;
   WHILE tables_array_length > 0 AND loop_count < 20 LOOP
     SELECT tables_array INTO aux_tables_array;


### PR DESCRIPTION
Further testing with the `delete_all_records` function showed that it can corrupt the new multi-region setup by deleting records from the `aws_regions` table. The table gets auto-restored, *but* the user's default region selection is lost in the process, so just adding that table to a blacklist for now.