### PR TITLE
feat: add ci check to detect changes in not current module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           node-version: 16.x
 
+      - name: Install dependencies
+        run: yarn
+
       - name: checks modified files
         run: yarn changes-in-version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Use Node.js 16.x
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
       - name: Run code style check
         run: yarn style
 
+  changes-in-latest-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: checks modified files
+        run: yarn changes-in-version
+
   common-test:
     runs-on: ubuntu-latest
     name: common tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 16.x
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: git fetch --depth=1
 
       - name: Use Node.js 16.x
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
       - name: checks modified files
         run: yarn changes-in-version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: git fetch --depth=1
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 16.x
         uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "yarn clean && tsc && copyfiles -u 1 src/**/*.sql dist/ && copyfiles -u 1 src/**/*.json dist/",
     "clean": "rm -rf dist",
     "lint": "tslint --project .",
+    "changes-in-version": "IASQL_ENV=ci ./scripts/check_changes_in_right_version.sh",
     "test": "IASQL_ENV=test jest -i",
     "test:local": "IASQL_ENV=test export $(cat .env | xargs) && yarn test",
     "coverage": "IASQL_ENV=test jest -i --coverage --forceExit",

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -8,6 +8,9 @@ echo "Current version is $CURRENT_VERSION"
 
 # check if there have been modifications on previous code
 MODIFIED_FILES=($(git diff --no-commit-id --name-only -r  origin/main...))
+echo "modified files are"
+echo $MODIFIED_FILES
+
 for FILE in "${MODIFIED_FILES[@]}"; do
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION
   if  [[ $FILE == src/modules* ]]; then

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -12,8 +12,9 @@ echo "Modified files are"
 echo $MODIFIED_FILES
 
 for FILE in "${MODIFIED_FILES[@]}"; do
+  echo "I pick $FILE"
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION
-  if  [[ $FILE == src/modules* ]]; then
+  if  [[ $FILE == src/modules* ]]; then    
     # need to check the version
     VERSION=$(echo $FILE|cut -d '/' -f 3)
     if [ "$VERSION" != "$CURRENT_VERSION" ]; then
@@ -24,4 +25,4 @@ for FILE in "${MODIFIED_FILES[@]}"; do
   fi
 done
 
-exit 1
+exit 0

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -6,6 +6,9 @@ echo "Checking that changes are in the right version"
 CURRENT_VERSION=$(npx ts-node src/scripts/latestVersion.ts)
 echo "Current version is $CURRENT_VERSION"
 
+# fetch all branches
+git fetch --all
+
 # check if there have been modifications on previous code
 MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $(git merge-base --fork-point main)))
 for FILE in "${MODIFIED_FILES[@]}"; do

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -7,10 +7,10 @@ CURRENT_VERSION=$(npx ts-node src/scripts/latestVersion.ts)
 echo "Current version is $CURRENT_VERSION"
 
 # fetch all branches
-git fetch --all
+git fetch --all --depth=1
 
 # check if there have been modifications on previous code
-MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $(git merge-base --fork-point main)))
+MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $(git merge-base --fork-point origin/main)))
 for FILE in "${MODIFIED_FILES[@]}"; do
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION
   if  [[ $FILE == src/modules* ]]; then

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -5,10 +5,9 @@ echo "Checking that changes are in the right version"
 # get the current development version
 CURRENT_VERSION=$(npx ts-node src/scripts/latestVersion.ts)
 echo "Current version is $CURRENT_VERSION"
-echo "Current branch is $GITHUB_BASE_REF"
 
 # check if there have been modifications on previous code
-MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $GITHUB_BASE_REF))
+MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $(git merge-base --fork-point main)))
 for FILE in "${MODIFIED_FILES[@]}"; do
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION
   if  [[ $FILE == src/modules* ]]; then

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -8,6 +8,8 @@ echo "Current version is $CURRENT_VERSION"
 
 # check if there have been modifications on previous code
 IFS='' MODIFIED_FILES=($(git diff --no-commit-id --name-only -r  origin/main...))
+echo "Modified files are"
+echo $MODIFIED_FILES
 
 for FILE in "${MODIFIED_FILES[@]}"; do
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+echo "Checking that changes are in the right version"
+
 # get the current development version
 CURRENT_VERSION=$(grep 'latestVersion' src/config/ci.ts | cut -d ':' -f 2 | sed "s/'//g" | sed "s/,//g")
+echo "Current version is $CURRENT_VERSION"
+echo "Current commit is $GITHUB_SHA"
 
 # check if there have been modifications on previous code
 MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA))
@@ -12,6 +16,7 @@ for FILE in "${MODIFIED_FILES[@]}"; do
     VERSION=$(echo $FILE|cut -d '/' -f 3)
     if [ "$VERSION" != "$CURRENT_VERSION" ]; then
       # incorrect version
+      echo "Error, out of version modifications found in file $FILE"
       exit 1
     fi
   fi

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -3,13 +3,12 @@
 echo "Checking that changes are in the right version"
 
 # get the current development version
-CURRENT_VERSION=$(grep 'latestVersion' src/config/ci.ts | cut -d ':' -f 2 | sed "s/'//g" | sed "s/,//g")
+CURRENT_VERSION=$(npx ts-node src/scripts/latestVersion.ts)
 echo "Current version is $CURRENT_VERSION"
-echo "Current commit is $GITHUB_SHA"
+echo "Current branch is $GITHUB_BASE_REF"
 
 # check if there have been modifications on previous code
-GITHUB_COMMIT_REF=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.head.sha)
-MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $GITHUB_COMMIT_REF))
+MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $GITHUB_BASE_REF))
 for FILE in "${MODIFIED_FILES[@]}"; do
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION
   if  [[ $FILE == src/modules* ]]; then

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -6,11 +6,7 @@ echo "Checking that changes are in the right version"
 CURRENT_VERSION=$(npx ts-node src/scripts/latestVersion.ts)
 echo "Current version is $CURRENT_VERSION"
 
-# fetch all branches
-git fetch --all --depth=1
-
 # check if there have been modifications on previous code
-
 MODIFIED_FILES=($(git diff --no-commit-id --name-only -r  origin/main...))
 for FILE in "${MODIFIED_FILES[@]}"; do
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# get the current development version
+CURRENT_VERSION=$(grep 'latestVersion' src/config/ci.ts | cut -d ':' -f 2 | sed "s/'//g" | sed "s/,//g")
+
+# check if there have been modifications on previous code
+MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA))
+for FILE in "${MODIFIED_FILES[@]}"; do
+  # if file has the pattern src/modules/ check that is just for CURRENT_VERSION
+  if  [[ $FILE == src/modules* ]]; then
+    # need to check the version
+    VERSION=$(echo $FILE|cut -d '/' -f 3)
+    if [ "$VERSION" != "$CURRENT_VERSION" ]; then
+      # incorrect version
+      exit 1
+    fi
+  fi
+done
+
+exit 1

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -7,6 +7,7 @@ CURRENT_VERSION=$(npx ts-node src/scripts/latestVersion.ts)
 echo "Current version is $CURRENT_VERSION"
 
 # check if there have been modifications on previous code
+git diff --no-commit-id --name-only -r  origin/main...
 MODIFIED_FILES=($(git diff --no-commit-id --name-only -r  origin/main...))
 echo "modified files are"
 echo $MODIFIED_FILES

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -7,10 +7,7 @@ CURRENT_VERSION=$(npx ts-node src/scripts/latestVersion.ts)
 echo "Current version is $CURRENT_VERSION"
 
 # check if there have been modifications on previous code
-git diff --no-commit-id --name-only -r  origin/main...
-MODIFIED_FILES=($(git diff --no-commit-id --name-only -r  origin/main...))
-echo "modified files are"
-echo $MODIFIED_FILES
+IFS='' MODIFIED_FILES=($(git diff --no-commit-id --name-only -r  origin/main...))
 
 for FILE in "${MODIFIED_FILES[@]}"; do
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -10,7 +10,8 @@ echo "Current version is $CURRENT_VERSION"
 git fetch --all --depth=1
 
 # check if there have been modifications on previous code
-MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $(git merge-base --fork-point origin/main)))
+
+MODIFIED_FILES=($(git diff --no-commit-id --name-only -r  origin/main...))
 for FILE in "${MODIFIED_FILES[@]}"; do
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION
   if  [[ $FILE == src/modules* ]]; then

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -7,16 +7,16 @@ CURRENT_VERSION=$(npx ts-node src/scripts/latestVersion.ts)
 echo "Current version is $CURRENT_VERSION"
 
 # check if there have been modifications on previous code
-IFS='' MODIFIED_FILES=($(git diff --no-commit-id --name-only -r  origin/main...))
-echo "Modified files are"
-echo $MODIFIED_FILES
+IFS=$'\n' MODIFIED_FILES=($(git diff --no-commit-id --name-only -r  origin/main...))
 
 for FILE in "${MODIFIED_FILES[@]}"; do
-  echo "I pick $FILE"
+  echo "file is $FILE"
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION
-  if  [[ $FILE == src/modules* ]]; then    
+  if  [[ "$FILE" == src/modules* ]]; then
+    echo "check version"
     # need to check the version
     VERSION=$(echo $FILE|cut -d '/' -f 3)
+    echo "version is $VERSION"
     if [ "$VERSION" != "$CURRENT_VERSION" ]; then
       # incorrect version
       echo "Error, out of version modifications found in file $FILE"

--- a/scripts/check_changes_in_right_version.sh
+++ b/scripts/check_changes_in_right_version.sh
@@ -8,7 +8,8 @@ echo "Current version is $CURRENT_VERSION"
 echo "Current commit is $GITHUB_SHA"
 
 # check if there have been modifications on previous code
-MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA))
+GITHUB_COMMIT_REF=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.head.sha)
+MODIFIED_FILES=($(git diff-tree --no-commit-id --name-only -r $GITHUB_COMMIT_REF))
 for FILE in "${MODIFIED_FILES[@]}"; do
   # if file has the pattern src/modules/ check that is just for CURRENT_VERSION
   if  [[ $FILE == src/modules* ]]; then

--- a/src/modules/0.0.16/aws_account/module.json
+++ b/src/modules/0.0.16/aws_account/module.json
@@ -1,4 +1,4 @@
 {
   "name": "aws_account",
   "dependencies": ["iasql_platform"]
-}aaaaa
+}

--- a/src/modules/0.0.16/aws_account/module.json
+++ b/src/modules/0.0.16/aws_account/module.json
@@ -1,4 +1,4 @@
 {
   "name": "aws_account",
   "dependencies": ["iasql_platform"]
-}
+}aaaaa


### PR DESCRIPTION
When working in a module sometimes there is the need to do a rebase and start working on newever version. This can bring rebase problems, such as leaving files in the older module. Add a check to prevent it.

Signed-off-by: Yolanda Robla <info@ysoft.biz>
Closes: #1283