### PR TITLE
Delete broken code

### DIFF
--- a/src/modules/0.0.17/aws_security_group/index.ts
+++ b/src/modules/0.0.17/aws_security_group/index.ts
@@ -305,11 +305,6 @@ class SecurityGroupMapper extends MapperBase<SecurityGroup> {
           await this.module.securityGroup.db.update(e, ctx);
           // Make absolutely sure it shows up in the memo
           ctx.memo.db.SecurityGroup[e.groupId ?? ''] = e;
-          const rules = ctx?.memo?.cloud?.SecurityGroupRule ?? [];
-          const relevantRules = rules.filter((r: SecurityGroupRule) => r.securityGroup.groupId === e.groupId);
-          if (relevantRules.length > 0) {
-            await this.module.securityGroupRule.db.update(relevantRules, ctx);
-          }
         } else {
           await this.deleteSecurityGroup(client.ec2client, {
             GroupId: e.groupId,

--- a/src/modules/0.0.18/aws_security_group/index.ts
+++ b/src/modules/0.0.18/aws_security_group/index.ts
@@ -305,11 +305,6 @@ class SecurityGroupMapper extends MapperBase<SecurityGroup> {
           await this.module.securityGroup.db.update(e, ctx);
           // Make absolutely sure it shows up in the memo
           ctx.memo.db.SecurityGroup[e.groupId ?? ''] = e;
-          const rules = ctx?.memo?.cloud?.SecurityGroupRule ?? [];
-          const relevantRules = rules.filter((r: SecurityGroupRule) => r.securityGroup.groupId === e.groupId);
-          if (relevantRules.length > 0) {
-            await this.module.securityGroupRule.db.update(relevantRules, ctx);
-          }
         } else {
           await this.deleteSecurityGroup(client.ec2client, {
             GroupId: e.groupId,

--- a/src/modules/0.0.21/aws_security_group/index.ts
+++ b/src/modules/0.0.21/aws_security_group/index.ts
@@ -10,7 +10,6 @@ import {
   paginateDescribeSecurityGroupRules,
   paginateDescribeSecurityGroups,
   IpPermission,
-  PrefixList,
   PrefixListId,
 } from '@aws-sdk/client-ec2';
 
@@ -309,11 +308,6 @@ class SecurityGroupMapper extends MapperBase<SecurityGroup> {
           await this.module.securityGroup.db.update(e, ctx);
           // Make absolutely sure it shows up in the memo
           ctx.memo.db.SecurityGroup[e.groupId ?? ''] = e;
-          const rules = ctx?.memo?.cloud?.SecurityGroupRule ?? [];
-          const relevantRules = rules.filter((r: SecurityGroupRule) => r.securityGroup.groupId === e.groupId);
-          if (relevantRules.length > 0) {
-            await this.module.securityGroupRule.db.update(relevantRules, ctx);
-          }
         } else {
           await this.deleteSecurityGroup(client.ec2client, {
             GroupId: e.groupId,
@@ -374,8 +368,6 @@ class SecurityGroupRuleMapper extends MapperBase<SecurityGroupRule> {
   };
 
   async sgrMapper(sgr: AwsSecurityGroupRule, ctx: Context) {
-    const client = (await ctx.getAwsClient()) as AWS;
-
     const out = new SecurityGroupRule();
     out.securityGroupRuleId = sgr?.SecurityGroupRuleId;
     out.securityGroup = await this.module.securityGroup.cloud.read(ctx, sgr?.GroupId);

--- a/src/modules/0.0.22/aws_security_group/index.ts
+++ b/src/modules/0.0.22/aws_security_group/index.ts
@@ -10,7 +10,6 @@ import {
   paginateDescribeSecurityGroupRules,
   paginateDescribeSecurityGroups,
   IpPermission,
-  PrefixList,
   PrefixListId,
 } from '@aws-sdk/client-ec2';
 
@@ -309,11 +308,6 @@ class SecurityGroupMapper extends MapperBase<SecurityGroup> {
           await this.module.securityGroup.db.update(e, ctx);
           // Make absolutely sure it shows up in the memo
           ctx.memo.db.SecurityGroup[e.groupId ?? ''] = e;
-          const rules = ctx?.memo?.cloud?.SecurityGroupRule ?? [];
-          const relevantRules = rules.filter((r: SecurityGroupRule) => r.securityGroup.groupId === e.groupId);
-          if (relevantRules.length > 0) {
-            await this.module.securityGroupRule.db.update(relevantRules, ctx);
-          }
         } else {
           await this.deleteSecurityGroup(client.ec2client, {
             GroupId: e.groupId,
@@ -374,8 +368,6 @@ class SecurityGroupRuleMapper extends MapperBase<SecurityGroupRule> {
   };
 
   async sgrMapper(sgr: AwsSecurityGroupRule, ctx: Context) {
-    const client = (await ctx.getAwsClient()) as AWS;
-
     const out = new SecurityGroupRule();
     out.securityGroupRuleId = sgr?.SecurityGroupRuleId;
     out.securityGroup = await this.module.securityGroup.cloud.read(ctx, sgr?.GroupId);


### PR DESCRIPTION
As part of figuring out why https://github.com/iasql/iasql-engine/pull/1363 is failing only for security groups, I added some debugging code and realized the memo-access line accidentally changed the type from an object to an array.

Logging showed that some of the object keys were numeric and some were strings, and most security group rules were duplicated, one with a numeric-cast-to-string key and one with the correct key, so I thought it was an accidental misuse of the array type at first, like this:

```js
damocles@zelbinion:~/alantech/iasql-engine(delete-broken-code)$ node
Welcome to Node.js v16.15.0.
Type ".help" for more information.
> const val = ['foo', 'bar'];
undefined
> val.foo = 'foo';
'foo'
> val.bar = 'bar';
'bar'
> console.log(val)
[ 'foo', 'bar', foo: 'foo', bar: 'bar' ]
undefined
>
```

The new code definitely `memo`izes correctly, so I tried fixing this, but it still breaks when doing that.

It took longer than it probably should have, but eventually I started logging the `typeof` output of things, realized it *is* an `object`, and confirmed that we aren't polluting the global prototype with a new `filter` method for `object`, and that the currently existing code is *crashing* when it reaches this point, and the *only* reason why things are working is:

1. The larger size of the `memo` causes this `Promise` to run just a bit longer.
2. The security group cloud delete forces the deletion of all of the rules here, so *eventually* an iteration of the `lazyLoader` loop decides that it doesn't need to run these and it succeeds.
3. Making the `memo` smaller makes it reach the error limit faster and then fail.

So I tried deleting this code, and locally the test suite works just fine, so making a PR for this. But not entirely sure what to do with the old versions, yet, since fixing the behavior of `@cloudId` will break earlier versions of the security group modules. :(