### PR TITLE
Clean only the selected region

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,11 @@ jobs:
             SELECT * FROM default_aws_region('${AWS_REGION}');
           ";
 
+          # Disable all non-default regions so we only try to clean the region we're using
+          psql postgres://postgres:test@localhost:5432/iasql -c "
+            UPDATE aws_regions SET is_enabled = false WHERE is_default = false;
+          ";
+
           echo "\nDebug log..."
           psql postgres://postgres:test@localhost:5432/iasql -c "
             SELECT * FROM aws_regions;


### PR DESCRIPTION
While we are partially migrated from single-region to multi-region, the cleanup script can break if a multi-region module is installed and has dependencies in another region that is managed by a single-region module.

This PR disables all regions but the default region to effectively make the multi-region modules behave like they were single region for the purposes of test account cleanup. Once we have multi-region fully implemented, this can be removed, along with other logic like selecting a region at all (which can be moved into the tests themselves and simplify the CI harnesses)