### PR TITLE
fix: allow comparison for strings and arrays on ec2 profiles

### DIFF
--- a/src/modules/0.0.22/aws_iam/index.ts
+++ b/src/modules/0.0.22/aws_iam/index.ts
@@ -385,8 +385,14 @@ class RoleMapper extends MapperBase<IamRole> {
     return arn.split('/').pop();
   }
   allowEc2Service(a: IamRole) {
+    console.log('role is');
+    console.log(a);
+    console.log(a.assumeRolePolicyDocument?.Statement);
     return a.assumeRolePolicyDocument?.Statement?.find(
-      (s: any) => s.Effect === 'Allow' && s.Principal?.Service === 'ec2.amazonaws.com',
+      (s: any) =>
+        s.Effect === 'Allow' &&
+        ((Array.isArray(s.Principal?.Service) && s.Principal?.Service.includes('ec2.amazonaws.com')) ||
+          s.Principal?.Service === 'ec2.amazonaws.com'),
     );
   }
 
@@ -422,6 +428,7 @@ class RoleMapper extends MapperBase<IamRole> {
         );
         const allowEc2Service = this.allowEc2Service(role);
         if (allowEc2Service) {
+          console.log('i allow ec2');
           await this.createInstanceProfile(client.iamClient, role.roleName);
           await this.attachRoleToInstanceProfile(client.iamClient, role.roleName);
         }

--- a/src/modules/0.0.22/aws_iam/index.ts
+++ b/src/modules/0.0.22/aws_iam/index.ts
@@ -385,9 +385,6 @@ class RoleMapper extends MapperBase<IamRole> {
     return arn.split('/').pop();
   }
   allowEc2Service(a: IamRole) {
-    console.log('role is');
-    console.log(a);
-    console.log(a.assumeRolePolicyDocument?.Statement);
     return a.assumeRolePolicyDocument?.Statement?.find(
       (s: any) =>
         s.Effect === 'Allow' &&
@@ -428,7 +425,6 @@ class RoleMapper extends MapperBase<IamRole> {
         );
         const allowEc2Service = this.allowEc2Service(role);
         if (allowEc2Service) {
-          console.log('i allow ec2');
           await this.createInstanceProfile(client.iamClient, role.roleName);
           await this.attachRoleToInstanceProfile(client.iamClient, role.roleName);
         }

--- a/test/modules/aws-iam-integration.ts
+++ b/test/modules/aws-iam-integration.ts
@@ -23,6 +23,7 @@ const userConfigPolicyArn = 'arn:aws:iam::aws:policy/AWSConfigUserAccess';
 const supportUserPolicyArn = 'arn:aws:iam::aws:policy/job-function/SupportUser';
 const lambdaRoleName = `${prefix}${dbAlias}lambda-${region}`;
 const ec2RoleName = `${prefix}${dbAlias}ec2-${region}`;
+const ec2RoleNameArray = `${prefix}${dbAlias}ec2Array-${region}`;
 const anotherRoleName = `${prefix}${dbAlias}another-${region}`;
 const principalServArr = `${prefix}${dbAlias}ppalservarr-${region}`;
 const attachAssumeTaskPolicy = JSON.stringify({
@@ -57,6 +58,18 @@ const attachAssumeEc2Policy = JSON.stringify({
       Effect: 'Allow',
       Principal: {
         Service: 'ec2.amazonaws.com',
+      },
+      Action: 'sts:AssumeRole',
+    },
+  ],
+});
+const attachAssumeEc2PolicyArray = JSON.stringify({
+  Version: '2012-10-17',
+  Statement: [
+    {
+      Effect: 'Allow',
+      Principal: {
+        Service: ['ec2.amazonaws.com'],
       },
       Action: 'sts:AssumeRole',
     },
@@ -177,6 +190,9 @@ describe('IAM Role Integration Testing', () => {
       VALUES ('${ec2RoleName}', '${attachAssumeEc2Policy}');
 
       INSERT INTO iam_role (role_name, assume_role_policy_document)
+      VALUES ('${ec2RoleNameArray}', '${attachAssumeEc2PolicyArray}');
+
+      INSERT INTO iam_role (role_name, assume_role_policy_document)
       VALUES ('${anotherRoleName}', '${attachAnotherPolicy}');
 
       INSERT INTO iam_role (role_name, assume_role_policy_document)
@@ -216,6 +232,18 @@ describe('IAM Role Integration Testing', () => {
     SELECT *
     FROM iam_role
     WHERE role_name = '${ec2RoleName}';
+  `,
+      (res: any[]) => expect(res.length).toBe(1),
+    ),
+  );
+
+  it(
+    'check a new role addition',
+    query(
+      `
+    SELECT *
+    FROM iam_role
+    WHERE role_name = '${ec2RoleNameArray}';
   `,
       (res: any[]) => expect(res.length).toBe(1),
     ),
@@ -397,6 +425,14 @@ describe('IAM Role Integration Testing', () => {
     'deletes the role',
     query(`
     DELETE FROM iam_role
+    WHERE role_name = '${ec2RoleNameArray}';
+  `),
+  );
+
+  it(
+    'deletes the role',
+    query(`
+    DELETE FROM iam_role
     WHERE role_name = '${anotherRoleName}';
   `),
   );
@@ -442,6 +478,18 @@ describe('IAM Role Integration Testing', () => {
     SELECT *
     FROM iam_role
     WHERE role_name = '${ec2RoleName}';
+  `,
+      (res: any[]) => expect(res.length).toBe(0),
+    ),
+  );
+
+  it(
+    'check deletes the role',
+    query(
+      `
+    SELECT *
+    FROM iam_role
+    WHERE role_name = '${ec2RoleNameArray}';
   `,
       (res: any[]) => expect(res.length).toBe(0),
     ),


### PR DESCRIPTION
The current check to know if we needed to create an instance profile was just looking at service.ec2 as string. But it can also be passed as an array so we also need to do this comparison

Signed-off-by: Yolanda Robla <info@ysoft.biz>
Closes: #1368