### PR TITLE
Handle tables and functions provisioned by sql-only modules

### DIFF
--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -515,7 +515,7 @@ export class ModuleBase {
       );
       this.provides.functions.push(
         ...fnStmts
-          .map((fs: any) => fs.RawStmt?.stmt?.CreateFunctionStmt?.funcname?.pop()?.String?.str)
+          .map((fns: any) => fns.RawStmt?.stmt?.CreateFunctionStmt?.funcname?.pop()?.String?.str)
           .filter((v: string | undefined) => !!v),
       );
     } catch (_) {

--- a/test/common/all-modules-have-tables.ts
+++ b/test/common/all-modules-have-tables.ts
@@ -1,0 +1,61 @@
+import * as iasql from '../../src/services/iasql';
+import {
+  runQuery,
+  finish,
+  execComposeUp,
+  execComposeDown,
+  runInstallAll,
+  runInstall,
+  runSync,
+} from '../helpers';
+
+const dbAlias = 'allmodulestest';
+
+const sync = runSync.bind(null, dbAlias);
+const query = runQuery.bind(null, dbAlias);
+const install = runInstall.bind(null, dbAlias);
+const installAll = runInstallAll.bind(null, dbAlias);
+
+jest.setTimeout(240000);
+beforeAll(async () => await execComposeUp());
+afterAll(async () => await execComposeDown());
+
+describe('Every module installed need to have at least a table', () => {
+  it('creates a new test db', done =>
+    void iasql.connect(dbAlias, 'not-needed', 'not-needed').then(...finish(done)));
+
+  it('installs the aws_account module', install(['aws_account']));
+
+  it(
+    'inserts aws credentials',
+    query(
+      `
+    INSERT INTO aws_credentials (access_key_id, secret_access_key)
+    VALUES ('${process.env.AWS_ACCESS_KEY_ID}', '${process.env.AWS_SECRET_ACCESS_KEY}')
+  `,
+      undefined,
+      false,
+    ),
+  );
+
+  it('syncs the regions', sync());
+
+  it(
+    'sets the default region',
+    query(`
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+  `),
+  );
+
+  it('installs all modules', installAll());
+
+  it('compare iasql_tables with iasql_modules_installed', query(`
+    SELECT *
+    FROM iasql_modules_installed()
+    WHERE module_name NOT LIKE 'iasql_%' AND concat_ws ('@', module_name, module_version) NOT IN (
+      SELECT module FROM iasql_tables
+    )
+  `, (res: any[]) => expect(res?.length).toBe(0)));
+
+  it('deletes the test db', done => void iasql.disconnect(dbAlias, 'not-needed').then(...finish(done)));
+});


### PR DESCRIPTION
The problem: SQL-only modules like `aws_ecs_simplified` does not correctly handle the tables and functions that should be  provisioned. As a consequence, after module installation, the module was not listed in `iasql_tables`.

The result after installing the module successfully in main branch:
![image](https://user-images.githubusercontent.com/5898639/196971717-ece70da5-a19b-43fd-9893-e582a43e6ba7.png)

How the schema looks like after installation in main branch:
![image](https://user-images.githubusercontent.com/5898639/196972097-a210de80-593f-4c4b-a59c-fab6a7eb101d.png)


The result after installing the module successfully in this branch:
![image](https://user-images.githubusercontent.com/5898639/196970474-da9a1fa6-ecd8-41f9-8ac7-b42ea722df3f.png)

How the schema looks like after installation in this branch:
![image](https://user-images.githubusercontent.com/5898639/196973300-3889892c-af78-4b62-b143-a1a4e7245f3f.png)


Resolves #1424 

