### PR TITLE
Handle application elb dns on route53 alias target

### DIFF
--- a/src/modules/0.0.22/aws_route53_hosted_zones/index.ts
+++ b/src/modules/0.0.22/aws_route53_hosted_zones/index.ts
@@ -335,7 +335,10 @@ class ResourceRecordSetMapper extends MapperBase<ResourceRecordSet> {
           resourceRecordSet.AliasTarget = {
             HostedZoneId: e.aliasTarget.loadBalancer?.canonicalHostedZoneId,
             EvaluateTargetHealth: e.aliasTarget.evaluateTargetHealth,
-            DNSName: e.aliasTarget.loadBalancer?.dnsName,
+            DNSName:
+              e.aliasTarget?.loadBalancer?.loadBalancerType === LoadBalancerTypeEnum.APPLICATION
+                ? `dualstack.${e.aliasTarget.loadBalancer?.dnsName}`
+                : e.aliasTarget.loadBalancer?.dnsName,
           };
         }
         await createResourceRecordSet(
@@ -354,7 +357,7 @@ class ResourceRecordSetMapper extends MapperBase<ResourceRecordSet> {
         // We map this into the same kind of entity as `obj`
         const newObject = { ...newResourceRecordSet, HostedZoneId: e.parentHostedZone.hostedZoneId };
         const newEntity = await this.resourceRecordSetMapper(newObject, ctx);
-        if (!newEntity) return;
+        if (!newEntity) continue;
         // We attach the original object's ID to this new one, indicating the exact record it is
         // replacing in the database.
         if (e.id) {


### PR DESCRIPTION
Not sure why [this error](https://github.com/iasql/iasql-engine/actions/runs/3335780686/jobs/5521185700) is intermittent, it might be a race condition, but sometimes we ignore some records that should have been there. Why? Because AWS prepends a `dualstack.` string to the load balancer DNS if it is from the same account and the type is `application` (or classic but we do not handle those).

Note from [AWS Docs](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer.html):
> The console prepends dualstack. to the DNS name of the application and Classic Load Balancer from the same AWS account only. When a client, such as a web browser, requests the IP address for your domain name (example.com) or subdomain name (www.example.com), the client can request an IPv4 address (an A record), an IPv6 address (an AAAA record), or both IPv4 and IPv6 addresses (in separate requests with IPv4 first). The dualstack. designation allows Route 53 to respond with the appropriate IP address for your load balancer based on which IP address format the client requested. You will need to prepend dualstack. for Application and Classic Load Balancer from the different account.


Resolves #1451 