### PR TITLE
Stabilize the ACM tests

### DIFF
--- a/src/services/aws_macros.ts
+++ b/src/services/aws_macros.ts
@@ -108,7 +108,10 @@ export class AWS {
       region: config.region,
       retryStrategy: this.slowRetryStrategy,
     });
-    this.acmClient = new ACM(config);
+    this.acmClient = new ACM({
+      ...config,
+      retryStrategy: this.slowRetryStrategy,
+    });
     this.appSyncClient = new AppSync(config);
     this.cloudfrontClient = new CloudFront(config);
     this.cbClient = new CodeBuild({


### PR DESCRIPTION
After reading through the entirety of the v0.0.21 and v0.0.22 acm modules, I can find zero changes that should impact the ability of Certificate.cloud.read to function correctly. Therefore I am presuming this is an upstream problem and I am attaching the "slow waiter retry" logic we use for AWS's crappier APIs. It seems to work locally, but let's see what the full CI says.