### PR TITLE
Drop CI setting default region from test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_TESTING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_TESTING }}
           A0_IASQL_API_TOKEN: ${{ secrets.A0_IASQL_API_TOKEN }}
-          AWS_REGION: us-east-1
 
   readonly-test:
     runs-on: ubuntu-latest
@@ -118,7 +117,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_READONLY_TESTING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_READONLY_TESTING }}
           A0_IASQL_API_TOKEN: ${{ secrets.A0_IASQL_API_TOKEN }}
-          AWS_REGION: us-east-1
 
   upgrade-test:
     runs-on: ubuntu-latest
@@ -141,7 +139,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_TESTING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_TESTING }}
           A0_IASQL_API_TOKEN: ${{ secrets.A0_IASQL_API_TOKEN }}
-          AWS_REGION: us-east-1
 
   setup-module-test:
     runs-on: ubuntu-latest
@@ -190,20 +187,11 @@ jobs:
           ACCOUNT_INDEX=$(echo $RESPONSE | jq '.[0]' || exit 1)
           echo "::set-output name=account_index::$(echo ${ACCOUNT_INDEX})"
 
-          # TODO: Drop regions when multi-region is done
-          regions=("ap-northeast-1" "ap-northeast-2" "ap-northeast-3" "ap-south-1" "ap-southeast-1" "ap-southeast-2" "ca-central-1" "eu-central-1" "eu-north-1" "eu-west-1" "eu-west-2" "eu-west-3" "sa-east-1" "us-east-2" "us-west-1" "us-west-2")
-          regionslen=${#regions[@]}
-          index=$(($RANDOM % $regionslen))
-          region=${regions[$index]}
-
-          echo "::set-output name=region::$(echo ${region})"
-
       - name: Pre-clean Test Account
         id: pre-clean-test-account
         env:
           IASQL_ENV: ci
           ACCOUNT_INDEX: ${{ steps['determine-test-account'].outputs['account_index'] }}
-          AWS_REGION: ${{ steps['determine-test-account'].outputs['region'] }}
           ACCESS_KEY_IDS: ${{ secrets.ACCESS_KEY_IDS }}
           SECRET_ACCESS_KEYS: ${{ secrets.SECRET_ACCESS_KEYS }}
         run: |
@@ -237,20 +225,6 @@ jobs:
             SELECT * FROM iasql_sync();
           ";
 
-          psql postgres://postgres:test@localhost:5432/iasql -c "
-            SELECT * FROM default_aws_region('${AWS_REGION}');
-          ";
-
-          # Disable all non-default regions so we only try to clean the region we're using
-          psql postgres://postgres:test@localhost:5432/iasql -c "
-            UPDATE aws_regions SET is_enabled = false WHERE is_default = false;
-          ";
-
-          echo "\nDebug log..."
-          psql postgres://postgres:test@localhost:5432/iasql -c "
-            SELECT * FROM aws_regions;
-          ";
-
           echo "\nInstalling all modules in iasql db..."
           psql postgres://postgres:test@localhost:5432/iasql -c "
             select iasql_install(
@@ -274,7 +248,6 @@ jobs:
           IASQL_ENV: test
           MODULES: ${{ needs.setup-module-test.outputs['test-modules'] }}
           ACCOUNT_INDEX: ${{ steps['determine-test-account'].outputs['account_index'] }}
-          AWS_REGION: ${{ steps['determine-test-account'].outputs['region'] }}
           ACCESS_KEY_IDS: ${{ secrets.ACCESS_KEY_IDS }}
           SECRET_ACCESS_KEYS: ${{ secrets.SECRET_ACCESS_KEYS }}
           STAGING_ACCESS_KEY_ID: ${{ secrets.STAGING_ACCESS_KEY_ID }}

--- a/test/common/all-modules-have-tables.ts
+++ b/test/common/all-modules-have-tables.ts
@@ -1,11 +1,12 @@
 import * as iasql from '../../src/services/iasql';
 import {
-  runQuery,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runInstallAll,
+  execComposeUp,
+  finish,
   runInstall,
+  runInstallAll,
+  runQuery,
   runSync,
 } from '../helpers';
 
@@ -15,6 +16,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const installAll = runInstallAll.bind(null, dbAlias);
+const region = defaultRegion();
 
 jest.setTimeout(360000);
 beforeAll(async () => await execComposeUp());
@@ -43,7 +45,7 @@ describe('Every module installed need to have at least a table', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -152,3 +152,25 @@ export function getKeyCertPair(domainName: string): string[] {
   );
   return [key, cert];
 }
+
+export function defaultRegion(overrideList?: string[]): string {
+  const regionList = overrideList ?? [
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ca-central-1",
+    "eu-central-1",
+    "eu-north-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "sa-east-1",
+    "us-east-2",
+    "us-west-1",
+    "us-west-2",
+  ];
+  return regionList[Math.floor(Math.random() * regionList.length)];
+}

--- a/test/modules/aws-account-integration.ts
+++ b/test/modules/aws-account-integration.ts
@@ -1,6 +1,7 @@
 import * as scheduler from '../../src/services/scheduler'
 import * as iasql from '../../src/services/iasql'
 import {
+  defaultRegion,
   execComposeDown,
   execComposeUp,
   finish,
@@ -20,6 +21,7 @@ const install = runInstall.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const runSql = iasql.runSql.bind(null, dbAlias, 'not-needed');
+const region = defaultRegion();
 
 jest.setTimeout(360000);
 beforeAll(async () => await execComposeUp());
@@ -29,7 +31,7 @@ describe('AwsAccount Integration Testing', () => {
   // TODO: Restore some mechanism to verify credentials
   /*it('does not create a test DB with fake credentials', (done) => void iasql.connect(
     dbAlias,
-    process.env.AWS_REGION ?? 'barf',
+    region,
     'fake',
     'credentials',
     'not-needed').then(
@@ -136,7 +138,7 @@ describe('AwsAccount Integration Testing', () => {
   it('does absolutely nothing when you apply this', apply());
 
   it('selects a default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('confirms that the default region was set', query(`
@@ -160,7 +162,7 @@ describe('AwsAccount Integration Testing', () => {
     SELECT * FROM aws_regions WHERE is_default = TRUE;
   `, (res: any[]) => {
     expect(res.length).toBe(1);
-    expect(res[0].region).toBe(process.env.AWS_REGION);
+    expect(res[0].region).toBe(region);
   }));
 
   it('updates the default region with the handy `default_aws_region` function', query(`

--- a/test/modules/aws-acm-import-integration.ts
+++ b/test/modules/aws-acm-import-integration.ts
@@ -1,15 +1,16 @@
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
-  runInstall,
-  runUninstall,
+  execComposeUp,
+  finish,
   getKeyCertPair,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
 } from '../helpers';
 
 const prefix = getPrefix();
@@ -22,6 +23,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_acm'];
 
 jest.setTimeout(360000);
@@ -43,13 +45,13 @@ describe('AwsAcm Import Integration Testing', () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('installs the acm module', install(modules));
 
   it('adds a new certificate to import', query(`
-    SELECT * FROM certificate_import('${cert}', '${key}', '${process.env.AWS_REGION}', '');
+    SELECT * FROM certificate_import('${cert}', '${key}', '${region}', '');
   `));
 
   it('check new certificate added', query(`
@@ -82,7 +84,7 @@ describe('AwsAcm Import Integration Testing', () => {
   `, (res: any[]) => expect(res.length).toBe(0)));
 
   it('import a certificate in non-default region', query(`
-    SELECT * FROM certificate_import('${cert}', '${key}', '${process.env.AWS_REGION}', '');
+    SELECT * FROM certificate_import('${cert}', '${key}', '${region}', '');
   `));
 
   it('verifies the certificate in the non-default region is created', query(`

--- a/test/modules/aws-acm-list-integration.ts
+++ b/test/modules/aws-acm-list-integration.ts
@@ -1,13 +1,14 @@
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
   runInstall,
+  runQuery,
+  runSync,
   runUninstall,
 } from '../helpers';
 
@@ -20,6 +21,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_acm'];
 
 jest.setTimeout(360000);
@@ -49,7 +51,7 @@ describe('AwsAcm List Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-acm-request-integration.ts
+++ b/test/modules/aws-acm-request-integration.ts
@@ -1,13 +1,14 @@
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
   runInstall,
+  runQuery,
+  runSync,
   runUninstall,
 } from '../helpers';
 
@@ -20,6 +21,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_acm', 'aws_route53_hosted_zones', 'aws_elb'];
 
 jest.setTimeout(360000);
@@ -49,7 +51,7 @@ describe('AwsAcm Request Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 
@@ -59,7 +61,7 @@ describe('AwsAcm Request Integration Testing', () => {
     'adds a new certificate to request with a domain without route53 support',
     (done) => {
       query(`
-        SELECT * FROM certificate_request('fakeDomain.com', 'DNS', '${process.env.AWS_REGION}', '');
+        SELECT * FROM certificate_request('fakeDomain.com', 'DNS', '${region}', '');
       `)((e: any) => {
         if (e instanceof Error) {
           return done();
@@ -74,7 +76,7 @@ describe('AwsAcm Request Integration Testing', () => {
   it(
     'adds a new certificate to request with a fake domain',
     query(`
-      SELECT * FROM certificate_request('fakeDomain.com', 'DNS', '${process.env.AWS_REGION}', '');
+      SELECT * FROM certificate_request('fakeDomain.com', 'DNS', '${region}', '');
     `),
   );
 
@@ -93,7 +95,7 @@ describe('AwsAcm Request Integration Testing', () => {
   it(
     'adds a new certificate to request',
     query(`
-      SELECT * FROM certificate_request('${domainName}', 'DNS', '${process.env.AWS_REGION}', '');
+      SELECT * FROM certificate_request('${domainName}', 'DNS', '${region}', '');
   `),
   );
 

--- a/test/modules/aws-api-gateway-integration.ts
+++ b/test/modules/aws-api-gateway-integration.ts
@@ -1,15 +1,16 @@
 import config from "../../src/config";
 import * as iasql from "../../src/services/iasql";
 import {
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
   getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
 } from "../helpers";
 
 const prefix = getPrefix();
@@ -21,6 +22,7 @@ const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
 const modules = ["aws_api_gateway"];
+const region = defaultRegion();
 const apiName = `${prefix}testApi`;
 
 jest.setTimeout(3600000);
@@ -43,7 +45,7 @@ describe("API Gateway Integration Testing", () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it("installs the API gateway module", install(modules));

--- a/test/modules/aws-api-gateway-integration.ts
+++ b/test/modules/aws-api-gateway-integration.ts
@@ -22,7 +22,23 @@ const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
 const modules = ["aws_api_gateway"];
-const region = defaultRegion();
+// the AWS website lied, API gateway also has restricted regions
+const region = defaultRegion([
+  'ap-northeast-1',
+  'ap-northeast-2',
+  'ap-south-1',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'ca-central-1',
+  'eu-central-1',
+  'eu-north-1',
+  'eu-west-1',
+  'eu-west-2',
+  'sa-east-1',
+  'us-east-2',
+  'us-west-1',
+  'us-west-2',
+]);
 const apiName = `${prefix}testApi`;
 
 jest.setTimeout(3600000);

--- a/test/modules/aws-api-gateway-multi-region-integration.ts
+++ b/test/modules/aws-api-gateway-multi-region-integration.ts
@@ -21,7 +21,23 @@ const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
-const region = defaultRegion();
+// the AWS website lied, API gateway also has restricted regions
+const region = defaultRegion([
+  'ap-northeast-1',
+  'ap-northeast-2',
+  'ap-south-1',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'ca-central-1',
+  'eu-central-1',
+  'eu-north-1',
+  'eu-west-1',
+  'eu-west-2',
+  'sa-east-1',
+  'us-east-2',
+  'us-west-1',
+  'us-west-2',
+]);
 const modules = ['aws_api_gateway'];
 
 jest.setTimeout(3600000);

--- a/test/modules/aws-api-gateway-multi-region-integration.ts
+++ b/test/modules/aws-api-gateway-multi-region-integration.ts
@@ -1,13 +1,13 @@
-import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
+  defaultRegion,
+  execComposeDown,
+  execComposeUp,
+  finish,
   getPrefix,
-  runQuery,
   runApply,
   runInstall,
-  finish,
-  execComposeUp,
-  execComposeDown,
+  runQuery,
   runSync,
 } from '../helpers';
 
@@ -21,6 +21,7 @@ const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_api_gateway'];
 
 jest.setTimeout(3600000);
@@ -50,7 +51,7 @@ describe('Api Gateway Multi-region Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 
@@ -104,7 +105,7 @@ describe('Api Gateway Multi-region Integration Testing', () => {
     'changes the region the API Gateway is located in',
     query(`
       UPDATE api
-      SET region = '${process.env.AWS_REGION}'
+      SET region = '${region}'
       WHERE name = '${apiName}';
   `),
   );
@@ -117,7 +118,7 @@ describe('Api Gateway Multi-region Integration Testing', () => {
       `
     SELECT *
     FROM api
-    WHERE name = '${apiName}' and region = '${process.env.AWS_REGION}';
+    WHERE name = '${apiName}' and region = '${region}';
   `,
       (res: any[]) => expect(res.length).toBe(1),
     ),

--- a/test/modules/aws-appsync-integration.ts
+++ b/test/modules/aws-appsync-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
   getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
 } from '../helpers';
 
 const prefix = getPrefix();
@@ -20,6 +21,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_appsync'];
 const apiName = `${prefix}testApi`;
 const {
@@ -56,7 +58,7 @@ describe('App Sync Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-appsync-multi-region-integration.ts
+++ b/test/modules/aws-appsync-multi-region-integration.ts
@@ -1,13 +1,14 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
+  defaultRegion,
+  execComposeDown,
+  execComposeUp,
+  finish,
   getPrefix,
-  runQuery,
   runApply,
   runInstall,
-  finish,
-  execComposeUp,
-  execComposeDown,
+  runQuery,
   runSync,
 } from '../helpers';
 
@@ -25,6 +26,7 @@ const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_appsync'];
 
 jest.setTimeout(3600000);
@@ -54,7 +56,7 @@ describe('App Sync Multi-region Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 
@@ -108,7 +110,7 @@ describe('App Sync Multi-region Integration Testing', () => {
     'changes the region the graphql api is located in',
     query(`
       UPDATE graphql_api
-      SET region = '${process.env.AWS_REGION}'
+      SET region = '${region}'
       WHERE name = '${apiName}';
   `),
   );
@@ -121,7 +123,7 @@ describe('App Sync Multi-region Integration Testing', () => {
       `
     SELECT *
     FROM graphql_api
-    WHERE name = '${apiName}' and region = '${process.env.AWS_REGION}';
+    WHERE name = '${apiName}' and region = '${region}';
   `,
       (res: any[]) => expect(res.length).toBe(1),
     ),

--- a/test/modules/aws-cloudfront-integration.ts
+++ b/test/modules/aws-cloudfront-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
   getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
 } from '../helpers';
 
 const prefix = getPrefix();
@@ -56,6 +57,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_cloudfront', 'aws_s3'];
 
 jest.setTimeout(620000);
@@ -84,7 +86,7 @@ describe('Cloudfront Integration Testing', () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it("installs the cloudfront module", install(modules));

--- a/test/modules/aws-cloudwatch-integration.ts
+++ b/test/modules/aws-cloudwatch-integration.ts
@@ -1,13 +1,14 @@
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
   runInstall,
+  runQuery,
+  runSync,
   runUninstall,
 } from '../helpers';
 
@@ -19,6 +20,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 
 const modules = ['aws_cloudwatch'];
 jest.setTimeout(360000);
@@ -48,7 +50,7 @@ describe('AwsCloudwatch Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-codebuild-integration.ts
+++ b/test/modules/aws-codebuild-integration.ts
@@ -1,5 +1,6 @@
 import * as iasql from '../../src/services/iasql';
 import {
+  defaultRegion,
   execComposeDown,
   execComposeUp,
   finish,
@@ -16,6 +17,7 @@ const uninstall = runUninstall.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_codebuild', 'aws_ecr'];
 
 const codebuildPolicyArn = 'arn:aws:iam::aws:policy/AWSCodeBuildAdminAccess';
@@ -62,7 +64,7 @@ describe('AwsCodebuild Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-codebuild-multi-region-integration.ts
+++ b/test/modules/aws-codebuild-multi-region-integration.ts
@@ -1,5 +1,6 @@
 import * as iasql from '../../src/services/iasql';
 import {
+  defaultRegion,
   execComposeDown,
   execComposeUp,
   finish,
@@ -14,6 +15,7 @@ const apply = runApply.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_codebuild', 'aws_ecr'];
 const nonDefaultRegion = 'us-east-1';
 
@@ -61,7 +63,7 @@ describe('AwsCodebuild Multi-region Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-codedeploy-integration.ts
+++ b/test/modules/aws-codedeploy-integration.ts
@@ -2,6 +2,7 @@ import { EC2 } from '@aws-sdk/client-ec2';
 
 import * as iasql from '../../src/services/iasql';
 import {
+  defaultRegion,
   execComposeDown,
   execComposeUp,
   finish,
@@ -22,7 +23,7 @@ const ubuntuAmiId =
   'resolve:ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id';
 
 const nonDefaultRegion = 'us-east-1';
-const region = process.env.AWS_REGION ?? '';
+const region = defaultRegion();
 const accessKeyId = process.env.AWS_ACCESS_KEY_ID ?? '';
 const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY ?? '';
 const ec2client = new EC2({
@@ -103,22 +104,6 @@ const ec2FilterTags = JSON.stringify([
   },
 ]);
 
-const revisionLocationv0 = JSON.stringify({
-  revisionType: 'GitHub',
-  gitHubLocation: {
-    repository: 'iasql/iasql-codedeploy-example',
-    commitId: 'cf6aa63cbd2502a5d1064363c2af5c56cc2107cc',
-  },
-});
-
-const revisionLocationv1 = JSON.stringify({
-  revisionType: 'GitHub',
-  gitHubLocation: {
-    repository: 'iasql/iasql-codedeploy-example',
-    commitId: '165582e107955f0b114a9d9d74cd2e4f198454a7',
-  },
-});
-
 const sgGroupName = `${prefix}sgcodedeploy`;
 
 let availabilityZone: string;
@@ -166,7 +151,7 @@ describe('AwsCodedeploy Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-codepipeline-integration.ts
+++ b/test/modules/aws-codepipeline-integration.ts
@@ -2,6 +2,7 @@ import { EC2 } from '@aws-sdk/client-ec2';
 
 import * as iasql from '../../src/services/iasql';
 import {
+  defaultRegion,
   execComposeDown,
   execComposeUp,
   finish,
@@ -20,6 +21,24 @@ const uninstall = runUninstall.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
+// codepipeline has a more limited region list
+const region = defaultRegion([
+  "ap-northeast-1",
+  "ap-northeast-2",
+  "ap-south-1",
+  "ap-southeast-1",
+  "ap-southeast-2",
+  "ca-central-1",
+  "eu-central-1",
+  "eu-north-1",
+  "eu-west-1",
+  "eu-west-2",
+  "eu-west-3",
+  "sa-east-1",
+  "us-east-2",
+  "us-west-1",
+  "us-west-2",
+]);
 const modules = ['aws_codepipeline', 'aws_s3', 'aws_codedeploy'];
 
 const codepipelinePolicyArn = 'arn:aws:iam::aws:policy/AWSCodePipelineFullAccess';
@@ -29,7 +48,6 @@ const bucket = `${prefix}-bucket`;
 
 const applicationNameForDeployment = `${prefix}${dbAlias}applicationForDeployment`;
 const deploymentGroupName = `${prefix}${dbAlias}deployment_group`;
-const region = `${process.env.AWS_REGION}`;
 const nonDefaultRegion = 'us-east-1';
 const codeDeployRoleName = `${prefix}-codedeploy-${region}`;
 const codePipelineRoleName = `${prefix}-codepipeline-${region}`;

--- a/test/modules/aws-dynamo-integration.ts
+++ b/test/modules/aws-dynamo-integration.ts
@@ -1,6 +1,17 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql'
-import { getPrefix, runQuery, runApply, runInstall, runUninstall, finish, execComposeUp, execComposeDown, runSync, } from '../helpers'
+import {
+  defaultRegion,
+  execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
+} from '../helpers'
 
 const prefix = getPrefix();
 const dbAlias = 'dynamotest';
@@ -10,6 +21,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_dynamo'];
 
 jest.setTimeout(960000);
@@ -31,7 +43,7 @@ describe('Dynamo Integration Testing', () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('installs the dynamo module', install(modules));
@@ -135,7 +147,7 @@ describe('Dynamo Integration Testing', () => {
 
   it('changes the region the table is located in', query(`
     UPDATE dynamo_table
-    SET region = '${process.env.AWS_REGION}'
+    SET region = '${region}'
     WHERE table_name = '${prefix}regiontest';
   `));
 
@@ -147,7 +159,7 @@ describe('Dynamo Integration Testing', () => {
     WHERE table_name = '${prefix}regiontest';
   `, (res: any[]) => {
     expect(res.length).toBe(1);
-    expect(res[0].region).toBe(process.env.AWS_REGION);
+    expect(res[0].region).toBe(region);
   }));
 
   it('removes the dynamo table', query(`

--- a/test/modules/aws-ec2-integration.ts
+++ b/test/modules/aws-ec2-integration.ts
@@ -3,19 +3,20 @@ import { EC2 } from '@aws-sdk/client-ec2';
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers';
 
 const dbAlias = 'ec2test';
-const region = process.env.AWS_REGION ?? '';
+const region = defaultRegion();
 const accessKeyId = process.env.AWS_ACCESS_KEY_ID ?? '';
 const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY ?? '';
 const ec2client = new EC2({
@@ -138,7 +139,7 @@ describe('EC2 Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 
@@ -180,7 +181,7 @@ describe('EC2 Integration Testing', () => {
           LIMIT 1;
         INSERT INTO instance_security_groups (instance_id, security_group_id) SELECT
           (SELECT id FROM instance WHERE tags ->> 'name' = '${prefix}-1'),
-          (SELECT id FROM security_group WHERE group_name='default' AND region = '${process.env.AWS_REGION}');
+          (SELECT id FROM security_group WHERE group_name='default' AND region = '${region}');
       COMMIT;
 
       BEGIN;
@@ -191,7 +192,7 @@ describe('EC2 Integration Testing', () => {
           LIMIT 1;
         INSERT INTO instance_security_groups (instance_id, security_group_id) SELECT
           (SELECT id FROM instance WHERE tags ->> 'name' = '${prefix}-2'),
-          (SELECT id FROM security_group WHERE group_name='default' AND region = '${process.env.AWS_REGION}');
+          (SELECT id FROM security_group WHERE group_name='default' AND region = '${region}');
       COMMIT;
     `)((e?: any) => {
       if (!!e) return done(e);
@@ -224,7 +225,7 @@ describe('EC2 Integration Testing', () => {
           LIMIT 1;
         INSERT INTO instance_security_groups (instance_id, security_group_id) SELECT
           (SELECT id FROM instance WHERE tags ->> 'name' = '${prefix}-1'),
-          (SELECT id FROM security_group WHERE group_name='default' AND region = '${process.env.AWS_REGION}');
+          (SELECT id FROM security_group WHERE group_name='default' AND region = '${region}');
       COMMIT;
 
       BEGIN;
@@ -235,7 +236,7 @@ describe('EC2 Integration Testing', () => {
           LIMIT 1;
         INSERT INTO instance_security_groups (instance_id, security_group_id) SELECT
           (SELECT id FROM instance WHERE tags ->> 'name' = '${prefix}-2'),
-          (SELECT id FROM security_group WHERE group_name='default' AND region = '${process.env.AWS_REGION}');
+          (SELECT id FROM security_group WHERE group_name='default' AND region = '${region}');
       COMMIT;
     `)((e?: any) => {
       if (!!e) return done(e);
@@ -1010,7 +1011,7 @@ describe('EC2 General Purpose Volume Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-ec2-multi-region.ts
+++ b/test/modules/aws-ec2-multi-region.ts
@@ -3,18 +3,19 @@ import { EC2 } from '@aws-sdk/client-ec2';
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
 } from '../helpers';
 
 const dbAlias = 'ec2multi';
-const region = process.env.AWS_REGION ?? '';
+const region = defaultRegion();
 const accessKeyId = process.env.AWS_ACCESS_KEY_ID ?? '';
 const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY ?? '';
 const ec2client = new EC2({
@@ -122,7 +123,7 @@ describe('EC2 Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 
@@ -137,7 +138,7 @@ describe('EC2 Integration Testing', () => {
         LIMIT 1;
       INSERT INTO instance_security_groups (instance_id, security_group_id) SELECT
         (SELECT id FROM instance WHERE tags ->> 'name' = '${prefix}-1'),
-        (SELECT id FROM security_group WHERE group_name='default' AND region = '${process.env.AWS_REGION}');
+        (SELECT id FROM security_group WHERE group_name='default' AND region = '${region}');
     `)((e?: any) => {
       if (!!e) return done(e);
       done();

--- a/test/modules/aws-ecs-ecr-integration.ts
+++ b/test/modules/aws-ecs-ecr-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runInstall,
-  runUninstall,
-  runQuery,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers';
 
 const {
@@ -21,7 +22,7 @@ const dbAlias = 'ecstest';
 const dbAliasSidecar = `${dbAlias}sync`;
 const sidecarSync = runSync.bind(null, dbAliasSidecar);
 const sidecarInstall = runInstall.bind(null, dbAliasSidecar);
-const region = process.env.AWS_REGION || 'barf';
+const region = defaultRegion();
 const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
@@ -394,7 +395,7 @@ describe('ECS Integration Testing', () => {
     query(`
     BEGIN;
       INSERT INTO service ("name", desired_count, subnets, assign_public_ip, cluster_id, task_definition_id, target_group_id)
-      VALUES ('${serviceRepositoryName}', ${serviceDesiredCount}, (select array(select subnet_id from subnet inner join vpc on vpc.id = subnet.vpc_id where is_default = true and vpc.region = '${process.env.AWS_REGION}' limit 3)), 'ENABLED', (SELECT id FROM cluster WHERE cluster_name = '${clusterName}'), (select id from task_definition where family = '${tdRepositoryFamily}' and region = '${region}' order by revision desc limit 1), (SELECT id FROM target_group WHERE target_group_name = '${serviceTargetGroupName}' and region = '${region}'));
+      VALUES ('${serviceRepositoryName}', ${serviceDesiredCount}, (select array(select subnet_id from subnet inner join vpc on vpc.id = subnet.vpc_id where is_default = true and vpc.region = '${region}' limit 3)), 'ENABLED', (SELECT id FROM cluster WHERE cluster_name = '${clusterName}'), (select id from task_definition where family = '${tdRepositoryFamily}' and region = '${region}' order by revision desc limit 1), (SELECT id FROM target_group WHERE target_group_name = '${serviceTargetGroupName}' and region = '${region}'));
 
       INSERT INTO service_security_groups (service_id, security_group_id)
       VALUES ((SELECT id FROM service WHERE name = '${serviceRepositoryName}'), (select id from security_group where group_name = '${securityGroup}' and region = '${region}' limit 1));

--- a/test/modules/aws-ecs-integration.ts
+++ b/test/modules/aws-ecs-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runInstall,
-  runUninstall,
-  runQuery,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers';
 
 const {
@@ -22,7 +23,7 @@ const dbAlias = 'ecstest';
 const dbAliasSidecar = `${dbAlias}sync`;
 const sidecarSync = runSync.bind(null, dbAliasSidecar);
 const sidecarInstall = runInstall.bind(null, dbAliasSidecar);
-const region = process.env.AWS_REGION || 'barf';
+const region = defaultRegion();
 const nonDefaultRegion = 'us-east-1';
 const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);

--- a/test/modules/aws-ecs-pub-ecr-integration.ts
+++ b/test/modules/aws-ecs-pub-ecr-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config'
 import * as iasql from '../../src/services/iasql'
 import {
-  getPrefix,
-  runInstall,
-  runUninstall,
-  runQuery,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers'
 
 const {
@@ -21,7 +22,7 @@ const dbAlias = 'ecstest';
 const dbAliasSidecar = `${dbAlias}sync`;
 const sidecarSync = runSync.bind(null, dbAliasSidecar);
 const sidecarInstall = runInstall.bind(null, dbAliasSidecar);
-const region = process.env.AWS_REGION || 'barf';
+const region = defaultRegion();
 const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
@@ -252,7 +253,7 @@ describe('ECS Integration Testing', () => {
   it('adds a new service', query(`
     BEGIN;
       INSERT INTO service ("name", desired_count, subnets, assign_public_ip, cluster_id, task_definition_id, target_group_id)
-      VALUES ('${servicePublicRepositoryName}', ${serviceDesiredCount}, (select array(select subnet_id from subnet inner join vpc on vpc.id = subnet.vpc_id where is_default = true and vpc.region = '${process.env.AWS_REGION}' limit 3)), 'ENABLED', (SELECT id FROM cluster WHERE cluster_name = '${clusterName}'), (select id from task_definition where family = '${tdPublicRepositoryFamily}' order by revision desc limit 1), (SELECT id FROM target_group WHERE target_group_name = '${serviceTargetGroupName}' and region = '${region}'));
+      VALUES ('${servicePublicRepositoryName}', ${serviceDesiredCount}, (select array(select subnet_id from subnet inner join vpc on vpc.id = subnet.vpc_id where is_default = true and vpc.region = '${region}' limit 3)), 'ENABLED', (SELECT id FROM cluster WHERE cluster_name = '${clusterName}'), (select id from task_definition where family = '${tdPublicRepositoryFamily}' order by revision desc limit 1), (SELECT id FROM target_group WHERE target_group_name = '${serviceTargetGroupName}' and region = '${region}'));
 
       INSERT INTO service_security_groups (service_id, security_group_id)
       VALUES ((SELECT id FROM service WHERE name = '${servicePublicRepositoryName}'), (select id from security_group where group_name = '${securityGroup}' and region = '${region}' limit 1));

--- a/test/modules/aws-ecs-simplified-integration.ts
+++ b/test/modules/aws-ecs-simplified-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql'
 import {
-  getPrefix,
-  runInstall,
-  runUninstall,
-  runQuery,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers'
 
 const {
@@ -18,7 +19,7 @@ const {
 
 const prefix = getPrefix();
 const dbAlias = 'ecssmptest';
-const region = process.env.AWS_REGION || 'barf';
+const region = defaultRegion();
 const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);

--- a/test/modules/aws-elasticache-integration.ts
+++ b/test/modules/aws-elasticache-integration.ts
@@ -3,15 +3,16 @@ import { ElastiCache } from '@aws-sdk/client-elasticache';
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
   getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
 } from '../helpers';
 
 const prefix = getPrefix();
@@ -27,7 +28,7 @@ const uninstall = runUninstall.bind(null, dbAlias);
 const cacheType = 'redis';
 const modules = ['aws_elasticache'];
 
-const region = process.env.AWS_REGION ?? '';
+const region = defaultRegion();
 const accessKeyId = process.env.AWS_ACCESS_KEY_ID ?? '';
 const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY ?? '';
 const elasticacheclient = new ElastiCache({
@@ -80,7 +81,7 @@ describe('Elasticache Integration Testing', () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('installs the elasticache module', install(modules));

--- a/test/modules/aws-elb-integration.ts
+++ b/test/modules/aws-elb-integration.ts
@@ -3,16 +3,17 @@ import { LoadBalancerStateEnum } from '@aws-sdk/client-elastic-load-balancing-v2
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
   getKeyCertPair,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
 } from '../helpers';
 
 const {
@@ -34,6 +35,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = [
   'aws_security_group',
   'aws_elb',
@@ -85,7 +87,7 @@ describe('ELB Integration Testing', () => {
     query(`
         UPDATE aws_regions
         SET is_default = TRUE
-        WHERE region = '${process.env.AWS_REGION}';
+        WHERE region = '${region}';
     `),
   );
 
@@ -301,7 +303,7 @@ describe('ELB Integration Testing', () => {
   it(
     'adds a new certificate to import',
     query(`
-      SELECT * FROM certificate_import('${cert}', '${key}', '${process.env.AWS_REGION}', '');
+      SELECT * FROM certificate_import('${cert}', '${key}', '${region}', '');
   `),
   );
 

--- a/test/modules/aws-iam-integration.ts
+++ b/test/modules/aws-iam-integration.ts
@@ -1,20 +1,21 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers';
 
 const prefix = getPrefix();
 const dbAlias = 'iamtest';
-const region = process.env.AWS_REGION ?? 'barf';
+const region = defaultRegion();
 const awsServiceRoleName = 'AWSServiceRoleForSupport';
 const taskRoleName = `${prefix}${dbAlias}task-${region}`;
 const taskPolicyArn = 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy';

--- a/test/modules/aws-lambda-integration.ts
+++ b/test/modules/aws-lambda-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers';
 
 const prefix = getPrefix();
@@ -52,6 +53,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_lambda'];
 
 jest.setTimeout(480000);
@@ -81,7 +83,7 @@ describe('Lambda Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-lambda-multi-region-integration.ts
+++ b/test/modules/aws-lambda-multi-region-integration.ts
@@ -1,12 +1,13 @@
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
 } from '../helpers';
 
@@ -21,16 +22,8 @@ const nonDefaultRegion = 'us-east-1';
 // }
 const lambdaFunctionCode =
   'UEsDBBQAAAAIADqB9VRxjjIufQAAAJAAAAAIABwAaW5kZXguanNVVAkAAzBe2WIwXtlidXgLAAEE9QEAAAQUAAAANcyxDoIwEIDhnae4MNFIOjiaOLI41AHj5NLUA5scV3K9Gojx3ZWB8R++H5c5iWb78vwkFDgD+LxygKFw0Ji4wTeythASKy5q4FPBFjkRWkpjU3f3zt1O8OAaDnDpr85mlchjHNYdcyFq4WjM3wpqEd5/26JXQT85P2H1/QFQSwECHgMUAAAACAA6gfVUcY4yLn0AAACQAAAACAAYAAAAAAABAAAApIEAAAAAaW5kZXguanNVVAUAAzBe2WJ1eAsAAQT1AQAABBQAAABQSwUGAAAAAAEAAQBOAAAAvwAAAAAA';
-// Base64 for zip file with the following code:
-// exports.handler =  async function(event, context) {
-//   console.log("EVENT: \n" + JSON.stringify(event, null, 3))
-//   return context.logStreamName
-// }
-const lambdaFunctionCodeUpdate =
-  'UEsDBBQAAAAIAI2Y9lTkWkK7fQAAAJAAAAAIABwAaW5kZXguanNVVAkAA5rY2mKc2NpidXgLAAEE9QEAAAQUAAAANcyxDoIwEIDhnae4MNFIuriZOLI41AHj5NLUA5scV3K9Gojx3ZWB8R++H5c5iWb78vwkFDgD+LxygKFw0Ji4wTeythASKy5q4FPBFjkRWkpjU3f3zt1O8OAaDnDpr85mlchjHNYdcyFq4WjM3wpqEd5/26JXQT85P2H1/QFQSwECHgMUAAAACACNmPZU5FpCu30AAACQAAAACAAYAAAAAAABAAAApIEAAAAAaW5kZXguanNVVAUAA5rY2mJ1eAsAAQT1AQAABBQAAABQSwUGAAAAAAEAAQBOAAAAvwAAAAAA';
 const lambdaFunctionHandler = 'index.handler';
 const lambdaFunctionRuntime14 = 'nodejs14.x';
-const lambdaFunctionRuntime16 = 'nodejs16.x';
 const lambdaFunctionRoleName = `${prefix}${dbAlias}-role`;
 const lambdaFunctionRoleTaskPolicyArn = 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole';
 const attachAssumeLambdaPolicy = JSON.stringify({
@@ -50,6 +43,7 @@ const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_lambda'];
 
 jest.setTimeout(480000);
@@ -79,7 +73,7 @@ describe('Lambda Multi-region Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 
@@ -143,7 +137,7 @@ describe('Lambda Multi-region Integration Testing', () => {
     'changes the region the lambda function is located in',
     query(`
       UPDATE lambda_function
-      SET region = '${process.env.AWS_REGION}', zip_b64 = '${lambdaFunctionCode}'
+      SET region = '${region}', zip_b64 = '${lambdaFunctionCode}'
       WHERE name = '${lambdaFunctionName}' and region = '${nonDefaultRegion}';
   `),
   );
@@ -156,7 +150,7 @@ describe('Lambda Multi-region Integration Testing', () => {
       `
     SELECT *
     FROM lambda_function
-    WHERE name = '${lambdaFunctionName}' and region = '${process.env.AWS_REGION}';
+    WHERE name = '${lambdaFunctionName}' and region = '${region}';
   `,
       (res: any[]) => expect(res.length).toBe(1),
     ),

--- a/test/modules/aws-memory-db-integration.ts
+++ b/test/modules/aws-memory-db-integration.ts
@@ -1,6 +1,17 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql'
-import { getPrefix, runQuery, runApply, runInstall, runUninstall, finish, execComposeUp, execComposeDown, runSync, } from '../helpers'
+import {
+  defaultRegion,
+  execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
+} from '../helpers'
 
 const prefix = getPrefix();
 const dbAlias = 'memorydbtest';
@@ -13,6 +24,23 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+// MemoryDB has a *very* constrained set of regions
+const region = defaultRegion([
+  'ap-northeast-1',
+  'ap-northeast-2',
+  'ap-south-1',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'ca-central-1',
+  'eu-central-1',
+  'eu-north-1',
+  'eu-west-1',
+  'eu-west-2',
+  'sa-east-1',
+  'us-east-2',
+  'us-west-1',
+  'us-west-2',
+]);
 const modules = ['aws_memory_db', 'aws_acm'];
 
 jest.setTimeout(1800000);
@@ -34,7 +62,7 @@ describe('MemoryDB Integration Testing', () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('installs the memory db module', install(modules));
@@ -78,7 +106,7 @@ describe('MemoryDB Integration Testing', () => {
     VALUES ('${clusterName}', (select id from subnet_group where subnet_group_name = '${subnetGroupName}'));
 
     INSERT INTO memory_db_cluster_security_groups (security_group_id, memory_db_cluster_id, region)
-    VALUES ((select id from security_group where group_name = 'default' and region = '${process.env.AWS_REGION}'), (select id from memory_db_cluster where cluster_name = '${clusterName}'), '${process.env.AWS_REGION}');
+    VALUES ((select id from security_group where group_name = 'default' and region = '${region}'), (select id from memory_db_cluster where cluster_name = '${clusterName}'), '${region}');
   `));
 
   it('undo changes', sync());
@@ -94,7 +122,7 @@ describe('MemoryDB Integration Testing', () => {
     VALUES ('${clusterName}', (select id from subnet_group where subnet_group_name = '${subnetGroupName}'));
 
     INSERT INTO memory_db_cluster_security_groups (security_group_id, memory_db_cluster_id, region)
-    VALUES ((select id from security_group where group_name = 'default' and region = '${process.env.AWS_REGION}'), (select id from memory_db_cluster where cluster_name = '${clusterName}'), '${process.env.AWS_REGION}');
+    VALUES ((select id from security_group where group_name = 'default' and region = '${region}'), (select id from memory_db_cluster where cluster_name = '${clusterName}'), '${region}');
   `));
 
   it('applies the change', apply());

--- a/test/modules/aws-rds-integration.ts
+++ b/test/modules/aws-rds-integration.ts
@@ -1,6 +1,17 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql'
-import { getPrefix, runQuery, runApply, runInstall, runUninstall, finish, execComposeUp, execComposeDown, runSync, } from '../helpers'
+import {
+  defaultRegion,
+  execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
+} from '../helpers'
 
 const prefix = getPrefix();
 const dbAlias = 'rdstest';
@@ -12,6 +23,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_security_group', 'aws_rds', 'aws_vpc'];
 
 jest.setTimeout(960000);
@@ -33,7 +45,7 @@ describe('RDS Integration Testing', () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('installs the rds module', install(modules));
@@ -41,10 +53,10 @@ describe('RDS Integration Testing', () => {
   it('creates an RDS instance', query(`
     BEGIN;
       INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', (SELECT name FROM availability_zone WHERE region = '${process.env.AWS_REGION}' LIMIT 1), 'postgres:13.4', 0);
+        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', (SELECT name FROM availability_zone WHERE region = '${region}' LIMIT 1), 'postgres:13.4', 0);
       INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
         (SELECT id FROM rds WHERE db_instance_identifier='${prefix}test'),
-        (SELECT id FROM security_group WHERE group_name='default' AND region = '${process.env.AWS_REGION}');
+        (SELECT id FROM security_group WHERE group_name='default' AND region = '${region}');
     COMMIT;
   `));
 
@@ -66,10 +78,10 @@ describe('RDS Integration Testing', () => {
   it('creates an RDS instance', query(`
     BEGIN;
       INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', (SELECT name FROM availability_zone WHERE region = '${process.env.AWS_REGION}' LIMIT 1), 'postgres:13.4', 0);
+        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', (SELECT name FROM availability_zone WHERE region = '${region}' LIMIT 1), 'postgres:13.4', 0);
       INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
         (SELECT id FROM rds WHERE db_instance_identifier='${prefix}test'),
-        (SELECT id FROM security_group WHERE group_name='default' AND region = '${process.env.AWS_REGION}');
+        (SELECT id FROM security_group WHERE group_name='default' AND region = '${region}');
     COMMIT;
   `));
 

--- a/test/modules/aws-rds-multi-region.ts
+++ b/test/modules/aws-rds-multi-region.ts
@@ -1,5 +1,15 @@
 import * as iasql from '../../src/services/iasql'
-import { getPrefix, runQuery, runApply, runInstall, finish, execComposeUp, execComposeDown, runSync, } from '../helpers'
+import {
+  defaultRegion,
+  execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+} from '../helpers'
 
 const prefix = getPrefix();
 const dbAlias = 'rdstest';
@@ -10,6 +20,7 @@ const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_security_group', 'aws_rds', 'aws_vpc'];
 
 jest.setTimeout(960000);
@@ -31,7 +42,7 @@ describe('RDS Multi-Region Testing', () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('installs the rds module', install(modules));
@@ -39,10 +50,10 @@ describe('RDS Multi-Region Testing', () => {
   it('creates an RDS instance', query(`
     BEGIN;
       INSERT INTO rds (db_instance_identifier, allocated_storage, db_instance_class, master_username, master_user_password, availability_zone, engine, backup_retention_period)
-        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', (SELECT name FROM availability_zone WHERE region = '${process.env.AWS_REGION}' LIMIT 1), 'postgres:13.4', 0);
+        VALUES ('${prefix}test', 20, 'db.t3.micro', 'test', 'testpass', (SELECT name FROM availability_zone WHERE region = '${region}' LIMIT 1), 'postgres:13.4', 0);
       INSERT INTO rds_security_groups (rds_id, security_group_id) SELECT
         (SELECT id FROM rds WHERE db_instance_identifier='${prefix}test'),
-        (SELECT id FROM security_group WHERE group_name='default' AND region = '${process.env.AWS_REGION}');
+        (SELECT id FROM security_group WHERE group_name='default' AND region = '${region}');
     COMMIT;
   `));
 

--- a/test/modules/aws-route53-hosted-zones-integration.ts
+++ b/test/modules/aws-route53-hosted-zones-integration.ts
@@ -2,15 +2,16 @@ import config from '../../src/config';
 import * as iasql from '../../src/services/iasql'
 import logger from '../../src/services/logger'
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers'
 
 const {
@@ -21,8 +22,9 @@ const {
 
 const prefix = getPrefix();
 const dbAlias = 'route53test';
-const domainName = `${dbAlias}${prefix}.${process.env.AWS_REGION}.com.`;
-const replaceDomainName = `${dbAlias}${prefix}replace.${process.env.AWS_REGION}.com.`;
+const region = defaultRegion();
+const domainName = `${dbAlias}${prefix}.${region}.com.`;
+const replaceDomainName = `${dbAlias}${prefix}replace.${region}.com.`;
 const resourceRecordSetName = `test.${domainName}`;
 const aliasResourceRecordSetName = `aliastest.${domainName}`;
 const resourceRecordSetMultilineName = `test.multiline.${replaceDomainName}`;
@@ -70,7 +72,7 @@ describe('Route53 Integration Testing', () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('installs module', install(modules));
@@ -135,7 +137,7 @@ describe('Route53 Integration Testing', () => {
   it('syncs the regions', syncStaging());
 
   it('sets the default region', queryStaging(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('installs module', installStaging(modules));

--- a/test/modules/aws-s3-integration.ts
+++ b/test/modules/aws-s3-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers';
 
 const prefix = getPrefix();
@@ -21,6 +22,7 @@ const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
 const modules = ['aws_s3'];
+const region = defaultRegion();
 const nonDefaultRegion = 'us-east-1';
 
 const policyJSON = {
@@ -88,7 +90,7 @@ describe('S3 Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 
@@ -141,7 +143,7 @@ describe('S3 Integration Testing', () => {
   it(
     'inserts content into bucket object',
     query(
-      `INSERT INTO bucket_object (bucket_name, key, region) VALUES ('${s3Name}', 'fake_bucket', '${process.env.AWS_REGION}')`,
+      `INSERT INTO bucket_object (bucket_name, key, region) VALUES ('${s3Name}', 'fake_bucket', '${region}')`,
     ),
   );
   it('applies the s3 object removal', apply());

--- a/test/modules/aws-secret-integration.ts
+++ b/test/modules/aws-secret-integration.ts
@@ -1,15 +1,16 @@
 import config from "../../src/config";
 import * as iasql from "../../src/services/iasql";
 import {
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
   getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
 } from "../helpers";
 
 const prefix = getPrefix();
@@ -22,6 +23,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ["aws_secrets_manager"];
 
 jest.setTimeout(360000);
@@ -44,7 +46,7 @@ describe("Secrets Manager Integration Testing", () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it("installs the secret module", install(modules));

--- a/test/modules/aws-security-group-integration.ts
+++ b/test/modules/aws-security-group-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
+  runUninstall,
 } from '../helpers';
 
 const prefix = getPrefix();
@@ -20,6 +21,7 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 const modules = ['aws_security_group', 'aws_vpc'];
 const randIPBlock = Math.floor(Math.random() * 254) + 1; // 0 collides with the default CIDR block
 const randIPBlock2 = Math.floor(Math.random() * 254) + 1; // 0 collides with the default CIDR block
@@ -51,7 +53,7 @@ describe('Security Group Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-security-group-multi-region-integration.ts
+++ b/test/modules/aws-security-group-multi-region-integration.ts
@@ -1,12 +1,13 @@
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runInstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion as dr,
   execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
   runSync,
 } from '../helpers';
 
@@ -14,7 +15,7 @@ const prefix = getPrefix();
 const dbAlias = 'sgtest';
 const sgName = `${prefix}${dbAlias}`;
 const nonDefaultRegion = 'us-east-1';
-const defaultRegion = process.env.AWS_REGION;
+const defaultRegion = dr();
 const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
@@ -48,7 +49,7 @@ describe('Security Group Multi region Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${defaultRegion}';
   `),
   );
 

--- a/test/modules/aws-tail-log-group.ts
+++ b/test/modules/aws-tail-log-group.ts
@@ -1,13 +1,14 @@
 import * as iasql from '../../src/services/iasql';
 import {
-  getPrefix,
-  runQuery,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
   runInstall,
+  runQuery,
+  runSync,
 } from '../helpers';
 
 const prefix = getPrefix();
@@ -23,7 +24,6 @@ const lambdaFunctionCode =
   'UEsDBBQAAAAIADqB9VRxjjIufQAAAJAAAAAIABwAaW5kZXguanNVVAkAAzBe2WIwXtlidXgLAAEE9QEAAAQUAAAANcyxDoIwEIDhnae4MNFIOjiaOLI41AHj5NLUA5scV3K9Gojx3ZWB8R++H5c5iWb78vwkFDgD+LxygKFw0Ji4wTeythASKy5q4FPBFjkRWkpjU3f3zt1O8OAaDnDpr85mlchjHNYdcyFq4WjM3wpqEd5/26JXQT85P2H1/QFQSwECHgMUAAAACAA6gfVUcY4yLn0AAACQAAAACAAYAAAAAAABAAAApIEAAAAAaW5kZXguanNVVAUAAzBe2WJ1eAsAAQT1AQAABBQAAABQSwUGAAAAAAEAAQBOAAAAvwAAAAAA';
 const lambdaFunctionHandler = 'index.handler';
 const lambdaFunctionRuntime14 = 'nodejs14.x';
-const lambdaFunctionRuntime16 = 'nodejs16.x';
 const lambdaFunctionRoleTaskPolicyArn = 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole';
 const attachAssumeLambdaPolicy = JSON.stringify({
   Version: '2012-10-17',
@@ -42,6 +42,7 @@ const apply = runApply.bind(null, dbAlias);
 const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
+const region = defaultRegion();
 
 const modules = ['aws_cloudwatch', 'aws_lambda'];
 jest.setTimeout(240000);
@@ -71,7 +72,7 @@ describe('AwsCloudwatch and AwsLambda Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-vpc-integration.ts
+++ b/test/modules/aws-vpc-integration.ts
@@ -1,15 +1,16 @@
 import config from '../../src/config';
 import * as iasql from '../../src/services/iasql';
 import {
-  runQuery,
-  runInstall,
-  runUninstall,
-  runApply,
-  finish,
-  execComposeUp,
+  defaultRegion,
   execComposeDown,
-  runSync,
+  execComposeUp,
+  finish,
   getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
 } from '../helpers';
 
 const prefix = getPrefix();
@@ -38,11 +39,12 @@ const sync = runSync.bind(null, dbAlias);
 const query = runQuery.bind(null, dbAlias);
 const install = runInstall.bind(null, dbAlias);
 const uninstall = runUninstall.bind(null, dbAlias);
+const region = defaultRegion();
 // We have to install the `aws_security_group` to test fully the integration even though is not being used,
 // since the `aws_vpc` module creates a `default` security group automatically.
 const modules = ['aws_vpc', 'aws_security_group'];
 
-const availabilityZone = `${process.env.AWS_REGION ?? 'barf'}a`;
+const availabilityZone = `${region}a`;
 const randIPBlock = Math.floor(Math.random() * 254) + 1; // 0 collides with the default CIDR block
 
 jest.setTimeout(360000);
@@ -72,7 +74,7 @@ describe('VPC Integration Testing', () => {
   it(
     'sets the default region',
     query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `),
   );
 

--- a/test/modules/aws-vpc-multi-region-integration.ts
+++ b/test/modules/aws-vpc-multi-region-integration.ts
@@ -1,8 +1,20 @@
 import * as iasql from '../../src/services/iasql'
-import { runQuery, runInstall, runUninstall, runApply, finish, execComposeUp, execComposeDown, runSync, getPrefix, } from '../helpers'
+import {
+  defaultRegion,
+  execComposeDown,
+  execComposeUp,
+  finish,
+  getPrefix,
+  runApply,
+  runInstall,
+  runQuery,
+  runSync,
+  runUninstall,
+} from '../helpers'
 
 const prefix = getPrefix();
 const dbAlias = 'vpctest';
+const region = defaultRegion();
 const nonDefaultRegion = 'us-east-1';
 const nonDefaultRegionAvailabilityZone = 'us-east-1a';
 const ng = `${prefix}${dbAlias}-ng`;
@@ -40,7 +52,7 @@ describe('VPC Multiregion Integration Testing', () => {
   it('syncs the regions', sync());
 
   it('sets the default region', query(`
-    UPDATE aws_regions SET is_default = TRUE WHERE region = '${process.env.AWS_REGION}';
+    UPDATE aws_regions SET is_default = TRUE WHERE region = '${region}';
   `));
 
   it('installs the vpc module', install(modules));
@@ -84,11 +96,11 @@ describe('VPC Multiregion Integration Testing', () => {
     DELETE FROM security_group WHERE vpc_id = (SELECT id FROM vpc WHERE tags ->> 'name' = '${prefix}-1');
     WITH updated_subnet AS (
       UPDATE subnet
-      SET region='${process.env.AWS_REGION}', availability_zone=(SELECT name FROM availability_zone WHERE region = '${process.env.AWS_REGION}' ORDER BY name LIMIT 1)
+      SET region='${region}', availability_zone=(SELECT name FROM availability_zone WHERE region = '${region}' ORDER BY name LIMIT 1)
       WHERE cidr_block='192.${randIPBlock}.0.0/16' AND availability_zone='${nonDefaultRegionAvailabilityZone}' AND region = '${nonDefaultRegion}'
     )
     UPDATE vpc
-    SET region='${process.env.AWS_REGION}'
+    SET region='${region}'
     WHERE cidr_block='192.${randIPBlock}.0.0/16' AND state='available' AND tags ->> 'name' = '${prefix}-1' AND region = '${nonDefaultRegion}';
   `));
 
@@ -101,12 +113,12 @@ describe('VPC Multiregion Integration Testing', () => {
 
   it('check vpc is available in the new region', query(`
     SELECT * FROM vpc 
-    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND state='available' AND tags ->> 'name' = '${prefix}-1' AND region = '${process.env.AWS_REGION}';
+    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND state='available' AND tags ->> 'name' = '${prefix}-1' AND region = '${region}';
   ` , (res: any) => expect(res.length).toBe(1)));
 
   it('check subnet is available in the new region', query(`
     SELECT * FROM subnet
-    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND availability_zone=(SELECT name FROM availability_zone WHERE region='${process.env.AWS_REGION}' ORDER BY name LIMIT 1) AND region = '${process.env.AWS_REGION}';
+    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND availability_zone=(SELECT name FROM availability_zone WHERE region='${region}' ORDER BY name LIMIT 1) AND region = '${region}';
   ` , (res: any) => expect(res.length).toBe(1)));
 
   it('uninstalls the vpc module', uninstall(
@@ -117,7 +129,7 @@ describe('VPC Multiregion Integration Testing', () => {
 
   it('check vpc is available in the new region', query(`
     SELECT * FROM vpc 
-    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND state='available' AND tags ->> 'name' = '${prefix}-1' AND region = '${process.env.AWS_REGION}';
+    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND state='available' AND tags ->> 'name' = '${prefix}-1' AND region = '${region}';
   ` , (res: any) => expect(res.length).toBe(1)));
 
   describe('Elastic IP and nat gateway multi-region', () => {
@@ -279,17 +291,17 @@ describe('VPC Multiregion Integration Testing', () => {
     WITH vpc as (
       SELECT id
       FROM vpc
-      WHERE cidr_block='192.${randIPBlock}.0.0/16' AND tags ->> 'name' = '${prefix}-1' AND region = '${process.env.AWS_REGION}'
+      WHERE cidr_block='192.${randIPBlock}.0.0/16' AND tags ->> 'name' = '${prefix}-1' AND region = '${region}'
     )
     DELETE FROM security_group
     USING vpc
     WHERE vpc_id = vpc.id;
 
     DELETE FROM subnet
-    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND region = '${process.env.AWS_REGION}';
+    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND region = '${region}';
 
     DELETE FROM vpc
-    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND tags ->> 'name' = '${prefix}-1' AND region = '${process.env.AWS_REGION}';
+    WHERE cidr_block='192.${randIPBlock}.0.0/16' AND tags ->> 'name' = '${prefix}-1' AND region = '${region}';
 
     WITH vpc as (
       SELECT id


### PR DESCRIPTION
As some AWS services have incomplete AWS region coverage, having a universally set region for all tests occasionally causes test failures that are not the fault of the module or the test itself, because it was asked to run in an unsupported region.

This PR devolves that decision back to the test suite, with a new `defaultRegion` helper test function that picks a singular region randomly from a list. That list can be overwritten by providing a new one to the function, which a few tests now do and should eliminate their flakiness.