### PR TITLE
merge all webcontent into one docusaurus instance

### DIFF
--- a/docs/blog/2021-09-14-intro.mdx
+++ b/docs/blog/2021-09-14-intro.mdx
@@ -1,0 +1,103 @@
+---
+slug: intro-iasql
+title: Introduction to Infrastructure as SQL
+authors: [depombo, dfellis, aguillenv]
+---
+
+What software you have deployed on what services and the interactions between them and the outside world is not a program, it is information about your infrastructure. Changing your infrastructure *is* a set of operations to perform, a program. A SQL database is a set of information and SQL queries read or change that data.
+
+**Infrastructure State is Data, Infrastructure Change is Code. It's as simple as that.**
+
+And manipulating your infrastructure in this way is natural.
+
+```sql
+INSERT INTO aws_ec2 (ami_id, ec2_instance_type_id)
+SELECT ami.id, ait.id
+FROM ec2_instance_type as ait, (
+    SELECT id
+    FROM   amis
+    WHERE  image_name LIKE 'amzn-ami-hvm-%'ORDER BY creation_date DESC
+    LIMIT 1
+) as ami
+WHERE  ait.instance_name = 't2.micro';
+```
+
+## **Relations and Types Matter for Infrastructure**
+
+Infrastructure as Code solutions do not have a good way of encoding dependencies across infrastructure pieces in a micro services architecture which makes it really hard to make and revert changes to infrastructure.
+
+Representing your infrastructure as SQL resolves the primary issue of YAML-based infrastructure tools by making the relations between pieces of your infrastructure first-class citizens, and enforcing type safety on the data and changes to it.
+
+You can't set the EC2 instance type as `t2.mucro` and have your deploy system try and fail to create such an instance. The `insert` statement will fail and tell you zero rows were inserted and you can quickly see why.
+
+Similarly, if you have a record in the `security_group` table, you can't delete it if there are any references to it in the `ec2_security_groups` join table. The relational structure of IaSQL prevents you from putting your infrastructure into an invalid state.
+
+## **New Powers: Explore, Query, and Automate Your Infrastructure**
+
+Because your infrastructure is presented as a SQL database, you can connect to it with a SQL client of your choice and explore what you have and what the possibilities are.
+
+```sql
+SHOW tables;
+```
+
+You can query for unusual usage patterns.
+
+```sql
+SELECT aws_ec2.*
+FROM aws_ec2
+INNER JOIN ec2_instance_type AS ait ON ait.id = aws_ec2.ec2_instance_type_id
+WHERE ait.vcpus > 8
+ORDER BY ait.vcpus DESC
+```
+
+And since it is a database, you can create your own tables with their own meaning and associate them with your infrastructure.
+
+```sql
+SELECT aws_ec2.*
+FROM aws_ec2
+INNER JOIN company_team_ec2s AS cte ON cte.aws_ec2_id = aws_ec2.id
+INNER JOIN company_teams AS ct ON ct.id = cte.company_team_id
+WHERE ct.name = 'Data Engineering'
+```
+
+Finally, your applications can know much more about what infrastructure they need than any auto-scaler solution out there. If you had a very infrequent but CPU/GPU-intensive job you need to handle at an unknown interval, you could give your application access to your IaSQL database and let it temporarily create and then destroy those resources.
+
+```jsx
+const ec2_instance_id = await iasql(`
+  INSERT INTO aws_ec2 (ami_id, ec2_instance_type_id)
+  SELECT ami.id, ait.id
+  FROM ec2_instance_type as ait, (
+      SELECT id
+      FROM amis
+      WHERE image_name = 'application-job-runner'
+  ) as ami
+  WHERE ait.instance_name = 'g3.4xlarge'
+  RETURNING id;
+`);
+await iasql(`
+  INSERT INTO ec2_security_groups (ec2_id, security_group_id)
+  SELECT ${ec2_instance_id}, sg.id
+  FROM security_groups AS sg
+  WHERE sg.name = 'application-job-group';
+`);
+// Only large-enough job runners will take it based on job metadata
+const result = await job.run(myMassiveJob); 
+await iasql(`
+  DELETE FROM aws_ec2
+  WHERE id = ${ec2_instance_id};
+`);
+```
+
+## **You Don't Need to Learn a New API (Probably)**
+
+Nearly all cloud backend systems depend on a database, and most likely a SQL database, so you do not need to learn a new language to manipulate the infrastructure in this way.
+
+And likely you're using a [migration system](https://en.wikipedia.org/wiki/Schema_migration) in your backend to review changes to your database, which you can continue to use here, making it code to be reviewed, just like Infrastructure-as-Code.
+
+## **You Can Test, Too**
+
+Since the safety guarantees are provided by the types and relations between tables, you can simply copy your production infrastructure database into a local database and run your changes/migration against that and verify it works before you run it on your actual Infrastructure-as-SQL database.
+
+## **Recover With Ease**
+
+It's 3AM and your service has gone down. You reverted the most recent IaSQL migration, but that didn't resolve the issue, and you aren't sure which change across which service today caused the outage. So, you simply replace the state of the IaSQL database with a snapshot from yesterday to bring everything back online to a known-good-state, and then take your time after you're well-rested to figure out what actually went wrong.

--- a/docs/blog/2022-04-14-os.mdx
+++ b/docs/blog/2022-04-14-os.mdx
@@ -1,0 +1,17 @@
+---
+slug: os-iasql
+title: UPDATE iasql SET source = 'open';
+authors: [depombo, dfellis, aguillenv]
+---
+
+We are excited to announce that [IaSQL](https://iasql.com) is now open source! The main repository is under https://github.com/iasql/iasql-engine. As perfectionists, we feel like IaSQL will never be truly ready. However, we believe IaSQL is at the point where it can start to be useful for developers managing infrastructure in the cloud. IaSQL is a SaaS that lets you model your infrastructure as data by maintaining a 2-way connection between your AWS account and a Postgres SQL database to represent the definitive state (and status) of your cloud which cannot be achieved with a static infrastructure declaration. This means that when you connect an AWS account to an IaSQL instance it automatically backfills the database with your existing cloud resources. No need to painstakingly redefine or reconcile your existing infrastructure, and IaSQL's [module system](https://docs.iasql.com/module/) means you can specify which parts of your cloud infrastructure you wish to control.
+
+<img class="screenshot" src="https://iasql.com/lib_TQbMwqDvYvWhOqVJ/ae7kf13uek0k6mul.gif" alt="drawing" width="400"/>
+
+IaSQL also makes it possible to express infrastructure changes as code that can be version controlled. This can be done with any [migration system](https://en.wikipedia.org/wiki/Schema_migration) for schema and data changes, or in a script using [idempotent SQL inserts](https://www.prisma.io/dataguide/postgresql/inserting-and-modifying-data/insert-on-conflict) more akin to [IaC](https://en.wikipedia.org/wiki/Infrastructure_as_code).
+
+PostgreSQL IaSQL databases can be provisioned and configured via our [dashboard](https://app.iasql.com). The dashboard calls the [engine](https://github.com/iasql/iasql-engine) which is a Node.js server written in Typescript that provisions unmodified PostgreSQL instances loaded with tables representing AWS services controlled via the [AWS SDK](https://www.npmjs.com/package/aws-sdk). AWS is our main focus at the moment, but we plan to support GCP, Azure and other cloud providers soon. This is an [updated list](https://github.com/iasql/iasql-engine#cloud-providers) of the AWS services that we currently support. Let us know if you need a specific AWS service and we should be able prioritize it!
+
+<img class="screenshot" src="https://iasql.com/lib_VymYUCjjDarpARbl/87bwoyulswfitjo5.png" alt="drawing" width="1000"/>
+
+We want to make it easier to write IaSQL modules, reduce waiting times when provisioning infrastructure, add more functionality to the existing AWS services, and so on. The list of things we want to build into IaSQL is long, but we want to do it in the open with your feedback and help. Drop us a line on [Discord](https://discord.com/invite/machGGczea)!

--- a/docs/blog/authors.yml
+++ b/docs/blog/authors.yml
@@ -1,0 +1,11 @@
+depombo:
+  name: Luis Fernando De Pombo
+  image_url: https://github.com/depombo.png
+
+dfellis:
+  name: David Ellis
+  image_url: https://github.com/dfellis.png
+
+aguillenv:
+  name: Alejandro Guillen
+  image_url: https://github.com/aguillenv.png

--- a/docs/docs/how-to/aws.md
+++ b/docs/docs/how-to/aws.md
@@ -25,7 +25,7 @@ aws_secret_access_key = <YOUR_SECRET_ACCESS_KEY>
 
 ## Add the necessary cloud services to the hosted database
 
-Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](/function) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
+Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](../reference/function.md) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
 
 :::note
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -2,7 +2,7 @@ const lightCodeTheme = require('prism-react-renderer/themes/nightOwlLight');
 const darkCodeTheme = require('prism-react-renderer/themes/nightOwl');
 
 const prodConfig = {
-  url: 'https://docs.iasql.com',
+  url: 'https://iasql.com',
   phKey: 'phc_WjwJsXXSuEl2R2zElUWL55mWpNIfWR8HrFvjxwlTGWH',
 };
 const localConfig = {
@@ -33,9 +33,12 @@ const config = process.env.IASQL_ENV === 'local' ? localConfig : prodConfig;
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          routeBasePath: '/',
+          routeBasePath: '/docs',
         },
-        blog: false,
+        blog: {
+          showReadingTime: true,
+          routeBasePath: '/blog',
+        },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
@@ -68,7 +71,7 @@ const config = process.env.IASQL_ENV === 'local' ? localConfig : prodConfig;
           alt: 'logo',
           src: 'img/logo.png',
           srcDark: 'img/logo_dark.png',
-          href: 'https://iasql.com',
+          href: '/',
           target: '_self',
         },
         items: [
@@ -76,6 +79,16 @@ const config = process.env.IASQL_ENV === 'local' ? localConfig : prodConfig;
             to: 'https://app.iasql.com',
             target: '_self',
             label: 'Dashboard',
+          },
+          {
+            to: 'docs',
+            target: '_self',
+            label: 'Docs',
+          },
+          {
+            to: 'blog',
+            target: '_self',
+            label: 'Blog',
           },
           {
             to: 'https://dbdocs.io/iasql/iasql',
@@ -89,7 +102,7 @@ const config = process.env.IASQL_ENV === 'local' ? localConfig : prodConfig;
           },
           {
             type: 'docsVersionDropdown',
-            position: 'right'
+            position: 'right',
           },
           {
             href: 'https://github.com/iasql/iasql-engine',
@@ -106,19 +119,19 @@ const config = process.env.IASQL_ENV === 'local' ? localConfig : prodConfig;
             title: 'Product',
             items: [
               {
-                label: 'Dashboard',
-                href: 'https://app.iasql.com',
-                target: '_self'
-              },
-              {
-                label: 'Schema',
-                href: 'https://dbdocs.io/iasql/iasql',
-                target: '_self'
+                label: 'Docs',
+                href: 'docs',
+                target: '_self',
               },
               {
                 label: 'Blog',
-                href: 'https://blog.iasql.com',
+                href: 'blog',
                 target: '_self',
+              },
+              {
+                label: 'Dashboard',
+                href: 'https://app.iasql.com',
+                target: '_self'
               },
               {
                 label: 'GitHub',

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -6,12 +6,18 @@
 
 /* You can override the default Infima variables here. */
 @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Montserrat:600&display=swap');
 
 :root {
+  --ifm-color-primary-light: #CEE4F3;
   --ifm-color-primary: #3D95CE;
-  --ifm-color-primary-dark: #194766;
+  --ifm-color-primary-dark: rgb(16, 34, 64);
+  --ifm-color-secondary-dark:  rgb(14, 61, 70);
+  --ifm-color-secondary: #95CE3D;
+  --ifm-color-secondary-light: #E4F3CE;
   --ifm-code-font-size: 90%;
   --ifm-font-family-base: 'Roboto';
+  --ifm-heading-font-family: 'Montserrat'
 }
 
 .docusaurus-highlight-code-line {
@@ -76,4 +82,18 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   /* TODO this is because the CSS is imported as a client module as well, and happens to be before Infima */
   padding: 5px !important;
   border-radius: var(--ifm-global-radius);
+}
+
+/* home */
+.hero--iasql, .footer {
+  background-image: linear-gradient(var(--ifm-color-primary-light), var(--ifm-color-secondary-light));
+}
+
+[data-theme='dark'] .hero--iasql, [data-theme='dark'] .footer {
+  background-image: linear-gradient(var(--ifm-color-primary-dark), var(--ifm-color-secondary-dark));
+}
+
+.card {
+  height: 15rem;
+  padding: 1rem;
 }

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+
+export default function Home() {
+  return (
+    <Layout title="Home" description="Cloud infrastructure as data in PostgreSQL" disableSwitch={true}>
+      <div className="hero hero--iasql">
+        <div className="container">
+          <div className="row">
+            <div className="col col--6 padding--md">
+              <h1 className="hero__title">Infrastructure as data in PostgreSQL</h1>
+              <p className="hero__subtitle">Manage and provision cloud infrastructure via a hosted PostgreSQL database. Simpler than IaC or the AWS UI</p>
+              <div>
+                <button className="button button--primary button--lg">Get Started</button>
+              </div>
+            </div>
+            <div className="col col--6 padding--md">
+              <img src={'https://iasql.com/lib_TQbMwqDvYvWhOqVJ/i5kxd5vazlgj28jh.gif'}></img>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="hero">
+        <div className="container">
+          <div className="row padding--md text--center">
+            <h1 style={{width: '100%'}}>How IaSQL works</h1>
+            <p className="hero__subtitle">IaSQL is an open-source SaaS that models cloud infrastructure as data by maintaining a 2-way connection between an AWS account and a hosted PostgreSQL database</p>
+          </div>
+          <div className="text--center">
+            <img style={{height: '25rem'}} src={'https://iasql.com/lib_TQbMwqDvYvWhOqVJ/ae7kf13uek0k6mul.gif'}></img>
+          </div>
+        </div>
+      </div>
+      <div className="hero hero--iasql">
+        <div className="container">
+          <div className="row padding--lg">
+            <div className="col col--4 padding--sm">
+              <div class="card">
+                <div class="card__header">
+                  <h3>Automatically import existing infrastructure</h3>
+                </div>
+                <div class="card__body">
+                  <p>
+                  Connect an AWS account to a hosted IaSQL DB to automatically backfill the database with your existing cloud resources. No need to redefine or reconcile existing infrastructure.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="col col--4 padding--sm">
+              <div class="card">
+                <div class="card__header">
+                  <h3>Don't learn a new API (Probably)</h3>
+                </div>
+                <div class="card__body">
+                  <p>
+                    No learning curve if you are already familiar with SQL. We provide an unmodified PostgreSQL database. Use any migration system, ORM or database connector.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="col col--4 padding--sm">
+              <div class="card">
+                <div class="card__header">
+                  <h3>The definitive state of your cloud</h3>
+                </div>
+                <div class="card__body">
+                  <p>
+                  IaSQL's module system lets you specify which parts of your cloud infrastructure you wish to control as tables in PostgreSQL                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="row padding--lg">
+            <img src={'https://iasql.com/lib_VymYUCjjDarpARbl/87bwoyulswfitjo5.png?w=1200&h=900&fit=max'}></img>
+          </div>
+        </div>
+      </div>
+      <div className="hero">
+        <div className="container">
+          <div className="row padding--md text--center">
+            <h1 style={{width: '100%'}}>Backed by</h1>
+          </div>
+          <div className="text--center">
+            <img style={{height: '10rem'}} src={'https://iasql.com/lib_cPtxZdFSoiujuclX/eo5c59g9ohkk9adh.png?w=1200&h=900&fit=max'}></img>
+          </div>
+        </div>
+      </div>
+      <div className="hero padding-bottom--xl">
+        <div className="container">
+          <div className="row text--center">
+            <h1 style={{width: '100%'}}>Ready to get started?</h1>
+          </div>
+          <div className="text--center">
+            <p className="hero__subtitle">Drop us a line on Discord if you have any questions!</p>
+            <button className="button button--primary button--lg">Get Started</button>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/docs/src/theme/NavbarItem.js
+++ b/docs/src/theme/NavbarItem.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import OriginalNavBarItem from '@theme-original/NavbarItem';
+import { useLocation }  from '@docusaurus/router';
+
+export default function NavbarItem(props) {
+  const { label, type } = props;
+  const { pathname } = useLocation();
+
+  if (pathname === '/') {
+    if (label === 'Dashboard') return null;
+    if (type === 'docsVersionDropdown') return null;
+    if (label === 'Schema') return null;
+  }
+
+  if (pathname.includes('blog')) {
+    if (label === 'Dashboard') return null;
+    if (label === 'Blog') return null;
+    if (type === 'docsVersionDropdown') return null;
+  }
+
+  if (pathname.includes('docs')) {
+    if (label === 'Docs') return null;
+    if (label === 'Blog') return null;
+  }
+
+  return (
+    <>
+      <OriginalNavBarItem {...props} />
+    </>
+  );
+}

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,1 @@
-docs.iasql.com
+iasql.com

--- a/docs/versioned_docs/version-0.0.17/how-to/aws.md
+++ b/docs/versioned_docs/version-0.0.17/how-to/aws.md
@@ -25,7 +25,7 @@ aws_secret_access_key = <YOUR_SECRET_ACCESS_KEY>
 
 ## Add the necessary cloud services to the hosted database
 
-Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](/function) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
+Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](../reference/function.md) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
 
 :::note
 

--- a/docs/versioned_docs/version-0.0.18/how-to/aws.md
+++ b/docs/versioned_docs/version-0.0.18/how-to/aws.md
@@ -25,7 +25,7 @@ aws_secret_access_key = <YOUR_SECRET_ACCESS_KEY>
 
 ## Add the necessary cloud services to the hosted database
 
-Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](/function) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
+Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](../reference/function.md) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
 
 :::note
 

--- a/docs/versioned_docs/version-0.0.20/how-to/aws.md
+++ b/docs/versioned_docs/version-0.0.20/how-to/aws.md
@@ -25,7 +25,7 @@ aws_secret_access_key = <YOUR_SECRET_ACCESS_KEY>
 
 ## Add the necessary cloud services to the hosted database
 
-Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](/function) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
+Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](../reference/function.md) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
 
 :::note
 

--- a/docs/versioned_docs/version-0.0.21/how-to/aws.md
+++ b/docs/versioned_docs/version-0.0.21/how-to/aws.md
@@ -25,7 +25,7 @@ aws_secret_access_key = <YOUR_SECRET_ACCESS_KEY>
 
 ## Add the necessary cloud services to the hosted database
 
-Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](/function) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
+Connect to your database and use the `iasql_install` IaSQL PostgreSQL [function](../reference/function.md) which is already loaded into your database to install different [modules](../concepts/module.md) and start managing different parts of your cloud account. Many different clients can be used to [connect](../how-to/connect.md) to a PostgreSQL database.
 
 :::note
 


### PR DESCRIPTION
porting over the landing page to docusaurus using react + [infima](https://infima.dev/) wasn't too bad. there are a few outdated things in the current landing page, but I figured I would port it as-is and then change it in follow up PRs. the dark mode doesn't work as nicely, but that can also be follow ups