### PR TITLE
Make 'aws_s3' uninstallable

### DIFF
--- a/src/modules/0.0.22/aws_s3/sql/before_uninstall.sql
+++ b/src/modules/0.0.22/aws_s3/sql/before_uninstall.sql
@@ -1,0 +1,11 @@
+DROP TRIGGER
+  block_s3_object_primary_key_update;
+
+DROP FUNCTION
+  block_s3_object_primary_key_update;
+
+DROP TRIGGER
+  block_s3_primary_key_update;
+
+DROP FUNCTION
+  block_s3_primary_key_update;

--- a/src/modules/0.0.23/aws_s3/sql/before_uninstall.sql
+++ b/src/modules/0.0.23/aws_s3/sql/before_uninstall.sql
@@ -1,0 +1,11 @@
+DROP TRIGGER
+  block_s3_object_primary_key_update;
+
+DROP FUNCTION
+  block_s3_object_primary_key_update;
+
+DROP TRIGGER
+  block_s3_primary_key_update;
+
+DROP FUNCTION
+  block_s3_primary_key_update;


### PR DESCRIPTION
I discovered this accidentally, but we forgot to define the down path for the custom triggers in the `aws_s3` module, so uninstalling and re-installing that module might cause issues at the moment.