### PR TITLE
Catch LogDNA errors

### DIFF
--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -16,7 +16,7 @@ const logFactory: LogFunctionFactory = scope => {
     const logfn = createLogger(config.logger.logDnaKey, {
       levels,
     });
-    logfn.on('error', (event) => {
+    logfn.on('error', event => {
       if (event.retrying) return;
       console.log('Fatal error in LogDNA', event);
     });

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -16,6 +16,10 @@ const logFactory: LogFunctionFactory = scope => {
     const logfn = createLogger(config.logger.logDnaKey, {
       levels,
     });
+    logfn.on('error', (event) => {
+      if (event.retrying) return;
+      console.log('Fatal error in LogDNA', event);
+    });
     if (config.logger.forceLocal) {
       return (level, message, meta) => {
         console.log(`${level}: ${message}`, meta);


### PR DESCRIPTION
There was a weird blip today with staging and production where they both restarted because of LogDNA errors escaping to the top of the event loop. LogDNA failures are not a fatal problem for the engine itself, so let's capture it and log them to CloudWatch if encountered, as pointed out here: https://github.com/logdna/logger-node/issues/24#issuecomment-712169987 by @aguillenv