### PR TITLE
Fix continuous mode in singular docker container

### DIFF
--- a/src/scripts/pg_hba.conf
+++ b/src/scripts/pg_hba.conf
@@ -87,7 +87,7 @@
 # maintenance (custom daily cronjobs, replication, and similar tasks).
 #
 # Database administrative login by Unix domain socket
-local   all             postgres                                trust
+local   all             postgres                                peer
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
@@ -95,10 +95,10 @@ local   all             postgres                                trust
 local   all             all                                     peer
 # IPv4 local connections:
 #host    all             all             127.0.0.1/32            scram-sha-256
-host    all             all             127.0.0.1/32            password
+host    all             all             127.0.0.1/32            trust
 # IPv6 local connections:
 #host    all             all             ::1/128                 scram-sha-256
-host    all             all             ::1/128                 password
+host    all             all             ::1/128                 trust
 # Allow replication connections from localhost, by a user with the
 # replication privilege.
 local   replication     all                                     peer


### PR DESCRIPTION
The permissions were too strict for `pg_cron` to work, before. Opening them up only for localhost connection (when pg_cron connects to itself within the docker container) resolves it.