### PR TITLE
Push to Github Container Registry instead of using artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
     needs:
       - setup-module-test
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
 
   build-and-push:
     runs-on: ubuntu-latest
+    needs:
+      - setup-module-test
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -170,6 +172,7 @@ jobs:
   module-test:
     runs-on: ubuntu-latest
     needs:
+      - setup-module-test
       - build-and-push
     name: module test ${{ matrix.module }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         run: echo "::set-output name=registry-image-tag::ghcr.io/iasql/iasql-engine:$GITHUB_SHA"
 
   build-and-push:
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,22 +144,21 @@ jobs:
         run: echo "::set-output name=test-module-names::$(npx jest **/modules/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: false
-          load: true
+          push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: iasql:latest
+          tags: ghcr.io/iasql/iasql-engine:$GITHUB_SHA
           outputs: type=docker,dest=/tmp/iasql-image.tar
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: iasql-image
-          path: /tmp/iasql-image.tar
-
 
   module-test:
     runs-on: ubuntu-latest
@@ -196,18 +195,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: iasql-image
-          path: /tmp
-
-      - name: Load image
-        run: |
-          docker load --input /tmp/iasql-image.tar
-          docker image ls -a
-
-
       - name: Pre-clean Test Account
         id: pre-clean-test-account
         env:
@@ -223,7 +210,7 @@ jobs:
 
           # Spin up the engine and a postgres instance
           # Temporarily export the engine port until it's only the Postgres port needed
-          docker run -p 5432:5432 -p 8088:8088 -e IASQL_ENV=ci --name iasql iasql &
+          docker run -p 5432:5432 -p 8088:8088 -e IASQL_ENV=ci --name iasql ghcr.io/iasql/iasql-engine:$GITHUB_SHA &
           while ! curl --output /dev/null --silent --head --fail http://localhost:8088/health; do sleep 1 && echo -n .; done;
 
           # connect `iasql` db to aws account for `apply`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
     outputs:
       test-modules: ${{ steps['set-test-modules'].outputs['test-modules'] }}
       set-test-module-names: ${{ steps['set-test-module-names'].outputs['test-module-names'] }}
+      registry-image-tag: ${{ steps['set-registry-image-tag'].outputs['registry-image-tag'] }}
     steps:
       - uses: actions/checkout@v3
       - run: yarn --prefer-offline
@@ -142,6 +143,13 @@ jobs:
       - id: set-test-module-names
         name: Set modules tests names
         run: echo "::set-output name=test-module-names::$(npx jest **/modules/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
+      - id: set-registry-image-tag
+        name: Set registry image tag
+        run: echo "::set-output name=registry-image-tag::ghcr.io/iasql/iasql-engine:$GITHUB_SHA"
+
+  build-and-push:
+    runs-on: ubuntu:latest
+    steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
@@ -157,12 +165,12 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: ghcr.io/iasql/iasql-engine:$GITHUB_SHA
+          tags: ${{ needs.setup-module-test.outputs.registry-image-tag }}
 
   module-test:
     runs-on: ubuntu-latest
     needs:
-      - setup-module-test
+      - build-and-push
     name: module test ${{ matrix.module }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha
           tags: ghcr.io/iasql/iasql-engine:$GITHUB_SHA
-          outputs: type=docker,dest=/tmp/iasql-image.tar
 
   module-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pre-clean Test Account
         id: pre-clean-test-account
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,9 +190,6 @@ jobs:
           node-version: 16.x
           cache: 'yarn'
 
-      - name: Install dependencies
-        run: yarn --prefer-offline
-
       - name: Determine Test Account To Use
         id: determine-test-account
         env:
@@ -276,6 +273,9 @@ jobs:
 
           # Shut down the engine
           docker container stop iasql
+
+      - name: Install dependencies
+        run: yarn --prefer-offline
 
       - name: Run modules tests
         timeout-minutes: 90


### PR DESCRIPTION
This is going to make CI faster because instead of using `upload-artifact` and `download-artifact` (which treat the image as a BLOB), we'll be uploading the image to the Github container registry which does not upload the layers that already exist and therefore the time of uploading the artifact will be significantly reduced.