### PR TITLE
Try to fix CI fails in lambda delete

### DIFF
--- a/src/modules/aws_lambda/mappers/lambda_function.ts
+++ b/src/modules/aws_lambda/mappers/lambda_function.ts
@@ -394,13 +394,12 @@ export class LambdaFunctionMapper extends MapperBase<LambdaFunction> {
     delete: async (es: LambdaFunction[], ctx: Context) => {
       for (const e of es) {
         const client = (await ctx.getAwsClient(e.region)) as AWS;
-        const cloudRecord = ctx?.memo?.cloud?.LambdaFunction?.[this.entityId(e)];
 
         // Update function configuration, decoupling the VPC to allow
         // network interfaces to be released and removed automatically
         const input: UpdateFunctionConfigurationCommandInput = {
           FunctionName: e.name,
-          Role: e.role?.arn ?? cloudRecord.role?.arn,
+          Role: e.role?.arn,
           Handler: e.handler,
           Description: e.description,
           MemorySize: e.memorySize,

--- a/src/modules/aws_lambda/mappers/lambda_function.ts
+++ b/src/modules/aws_lambda/mappers/lambda_function.ts
@@ -394,12 +394,13 @@ export class LambdaFunctionMapper extends MapperBase<LambdaFunction> {
     delete: async (es: LambdaFunction[], ctx: Context) => {
       for (const e of es) {
         const client = (await ctx.getAwsClient(e.region)) as AWS;
+        const cloudRecord = ctx?.memo?.cloud?.LambdaFunction?.[this.entityId(e)];
 
         // Update function configuration, decoupling the VPC to allow
         // network interfaces to be released and removed automatically
         const input: UpdateFunctionConfigurationCommandInput = {
           FunctionName: e.name,
-          Role: e.role.arn,
+          Role: e.role?.arn ?? cloudRecord.role?.arn,
           Handler: e.handler,
           Description: e.description,
           MemorySize: e.memorySize,


### PR DESCRIPTION
Example failure:
https://github.com/iasql/iasql-engine/actions/runs/3666393565/jobs/6198087937#step:7:13301

Happens in LambdaFunction `cloud.delete` when the role does not exist in the database. I initially added `e.role?.arn` and then tried to use the cloud entity value instead.