### PR TITLE
Fix the retry bug in Jest tests

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -32,6 +32,8 @@ export interface ConfigInterface {
     environment: string;
     release?: string; // Make it nullable so we can attach it later
   };
+  // For the issue caused by Jest VM and instanceof issues on AWS SDK in test environment
+  overrideAwsRetryDecider?: boolean;
 }
 
 export const throwError = (message: string): never => {

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -18,6 +18,7 @@ const config: ConfigInterface = {
     test: true,
     forceLocal: false,
   },
+  overrideAwsRetryDecider: true,
 };
 
 export default config;

--- a/src/services/aws_macros.ts
+++ b/src/services/aws_macros.ts
@@ -88,7 +88,7 @@ export class AWS {
         if (!error) {
           return false;
         }
-        if (error.name !== 'Error')
+        if (error.message.includes('AWS SDK error wrapper'))
           // default behavior when running outside Jest
           return defaultRetryDecider(error);
         else return true; // jest has messed the error object

--- a/src/services/aws_macros.ts
+++ b/src/services/aws_macros.ts
@@ -118,50 +118,50 @@ export class AWS {
         ),
     });
 
-    this.region = config.region;
+    this.region = awsConfig.region;
     this.apiGatewayClient = new ApiGatewayV2({
-      credentials: config.credentials,
-      region: config.region,
+      credentials: awsConfig.credentials,
+      region: awsConfig.region,
       retryStrategy: this.slowRetryStrategy,
     });
     this.acmClient = new ACM({
-      ...config,
+      ...awsConfig,
       retryStrategy: this.slowRetryStrategy,
     });
-    this.appSyncClient = new AppSync(config);
-    this.cloudfrontClient = new CloudFront(config);
+    this.appSyncClient = new AppSync(awsConfig);
+    this.cloudfrontClient = new CloudFront(awsConfig);
     this.cbClient = new CodeBuild({
-      credentials: config.credentials,
-      region: config.region,
+      credentials: awsConfig.credentials,
+      region: awsConfig.region,
       retryStrategy: this.codeBuildRetryStrategy,
     });
-    this.cdClient = new CodeDeploy(config);
-    this.cpClient = new CodePipeline(config);
-    this.cwClient = new CloudWatchLogs(config);
+    this.cdClient = new CodeDeploy(awsConfig);
+    this.cpClient = new CodePipeline(awsConfig);
+    this.cwClient = new CloudWatchLogs(awsConfig);
     this.cloudwatchClient = new CloudWatch(config);
-    this.dynamoClient = new DynamoDB(config);
-    this.elasticacheClient = new ElastiCache(config);
-    this.ec2client = new EC2(config);
-    this.ecrClient = new ECR(config);
-    this.ecsClient = new ECS(config);
-    this.elbClient = new ElasticLoadBalancingV2(config);
+    this.dynamoClient = new DynamoDB(awsConfig);
+    this.elasticacheClient = new ElastiCache(awsConfig);
+    this.ec2client = new EC2(awsConfig);
+    this.ecrClient = new ECR(awsConfig);
+    this.ecsClient = new ECS(awsConfig);
+    this.elbClient = new ElasticLoadBalancingV2(awsConfig);
     this.iamClient = new IAM({
-      credentials: config.credentials,
-      region: config.region,
+      credentials: awsConfig.credentials,
+      region: awsConfig.region,
       retryStrategy: this.slowRetryStrategy,
     });
     this.lambdaClient = new Lambda({
-      ...config,
+      ...awsConfig,
       retryStrategy: this.slowRetryStrategy,
     });
-    this.rdsClient = new RDS(config);
-    this.route53Client = new Route53(config);
-    this.secretsClient = new SecretsManager(config);
-    this.ssmClient = new SSM(config);
-    this.memoryDBClient = new MemoryDB(config);
-    this.s3Client = new S3(config);
+    this.rdsClient = new RDS(awsConfig);
+    this.route53Client = new Route53(awsConfig);
+    this.secretsClient = new SecretsManager(awsConfig);
+    this.ssmClient = new SSM(awsConfig);
+    this.memoryDBClient = new MemoryDB(awsConfig);
+    this.s3Client = new S3(awsConfig);
     // Service endpoint only available in 'us-east-1' https://docs.aws.amazon.com/general/latest/gr/ecr-public.html
-    this.ecrPubClient = new ECRPUBLIC({ credentials: config.credentials, region: 'us-east-1' });
+    this.ecrPubClient = new ECRPUBLIC({ credentials: awsConfig.credentials, region: 'us-east-1' });
   }
 }
 

--- a/src/services/aws_macros.ts
+++ b/src/services/aws_macros.ts
@@ -138,7 +138,7 @@ export class AWS {
     this.cdClient = new CodeDeploy(awsConfig);
     this.cpClient = new CodePipeline(awsConfig);
     this.cwClient = new CloudWatchLogs(awsConfig);
-    this.cloudwatchClient = new CloudWatch(config);
+    this.cloudwatchClient = new CloudWatch(awsConfig);
     this.dynamoClient = new DynamoDB(awsConfig);
     this.elasticacheClient = new ElastiCache(awsConfig);
     this.ec2client = new EC2(awsConfig);

--- a/src/services/aws_macros.ts
+++ b/src/services/aws_macros.ts
@@ -81,28 +81,22 @@ export class AWS {
   memoryDBClient: MemoryDB;
   slowRetryStrategy: StandardRetryStrategy;
   codeBuildRetryStrategy: StandardRetryStrategy;
-  defaultRetryStrategy: StandardRetryStrategy;
 
   constructor(config: AWSConfig) {
-    const jestTunedRetryDecider = (error: any) => {
-      // copied the default behavior from aws-sdk to fix the problem caused by Jest on isRetryableByTrait
-      if (!error) {
-        return false;
-      }
-      if (IASQL_ENV === 'test' && error.message.includes('AWS SDK error wrapper')) {
-        // jest has messed the error object
-        return true;
-      }
-      // default behavior when running outside Jest
-      return defaultRetryDecider(error);
-    };
     // declare a specific slow retry strategy, to reuse in slow apis
-    this.defaultRetryStrategy = new StandardRetryStrategy(async () => 3, {
-      retryDecider: jestTunedRetryDecider,
-    });
-
     this.slowRetryStrategy = new StandardRetryStrategy(async () => SLOW_STRATEGY_RETRIES, {
-      retryDecider: jestTunedRetryDecider,
+      retryDecider: error => {
+        // copied the default behavior from aws-sdk to fix the problem caused by Jest on isRetryableByTrait
+        if (!error) {
+          return false;
+        }
+        if (IASQL_ENV === 'test' && error.message.includes('AWS SDK error wrapper')) {
+          // jest has messed the error object
+          return true;
+        }
+        // default behavior when running outside Jest
+        return defaultRetryDecider(error);
+      },
       delayDecider: (_, attempts) =>
         Math.floor(
           Math.min(
@@ -134,23 +128,23 @@ export class AWS {
       ...config,
       retryStrategy: this.slowRetryStrategy,
     });
-    this.appSyncClient = new AppSync({ ...config, retryStrategy: this.defaultRetryStrategy });
+    this.appSyncClient = new AppSync(config);
     this.cloudfrontClient = new CloudFront(config);
     this.cbClient = new CodeBuild({
       credentials: config.credentials,
       region: config.region,
       retryStrategy: this.codeBuildRetryStrategy,
     });
-    this.cdClient = new CodeDeploy({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.cpClient = new CodePipeline({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.cwClient = new CloudWatchLogs({ ...config, retryStrategy: this.defaultRetryStrategy });
+    this.cdClient = new CodeDeploy(config);
+    this.cpClient = new CodePipeline(config);
+    this.cwClient = new CloudWatchLogs(config);
     this.cloudwatchClient = new CloudWatch(config);
-    this.dynamoClient = new DynamoDB({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.elasticacheClient = new ElastiCache({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.ec2client = new EC2({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.ecrClient = new ECR({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.ecsClient = new ECS({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.elbClient = new ElasticLoadBalancingV2({ ...config, retryStrategy: this.defaultRetryStrategy });
+    this.dynamoClient = new DynamoDB(config);
+    this.elasticacheClient = new ElastiCache(config);
+    this.ec2client = new EC2(config);
+    this.ecrClient = new ECR(config);
+    this.ecsClient = new ECS(config);
+    this.elbClient = new ElasticLoadBalancingV2(config);
     this.iamClient = new IAM({
       credentials: config.credentials,
       region: config.region,
@@ -160,18 +154,14 @@ export class AWS {
       ...config,
       retryStrategy: this.slowRetryStrategy,
     });
-    this.rdsClient = new RDS({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.route53Client = new Route53({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.secretsClient = new SecretsManager({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.ssmClient = new SSM({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.memoryDBClient = new MemoryDB({ ...config, retryStrategy: this.defaultRetryStrategy });
-    this.s3Client = new S3({ ...config, retryStrategy: this.defaultRetryStrategy });
+    this.rdsClient = new RDS(config);
+    this.route53Client = new Route53(config);
+    this.secretsClient = new SecretsManager(config);
+    this.ssmClient = new SSM(config);
+    this.memoryDBClient = new MemoryDB(config);
+    this.s3Client = new S3(config);
     // Service endpoint only available in 'us-east-1' https://docs.aws.amazon.com/general/latest/gr/ecr-public.html
-    this.ecrPubClient = new ECRPUBLIC({
-      credentials: config.credentials,
-      region: 'us-east-1',
-      retryStrategy: this.defaultRetryStrategy,
-    });
+    this.ecrPubClient = new ECRPUBLIC({ credentials: config.credentials, region: 'us-east-1' });
   }
 }
 

--- a/src/services/aws_macros.ts
+++ b/src/services/aws_macros.ts
@@ -24,7 +24,7 @@ import { SecretsManager } from '@aws-sdk/client-secrets-manager';
 import { SSM } from '@aws-sdk/client-ssm';
 import { defaultRetryDecider, StandardRetryStrategy } from '@aws-sdk/middleware-retry';
 
-import { IASQL_ENV } from '../config';
+import config from '../config';
 
 type AWSCreds = {
   accessKeyId: string;
@@ -82,7 +82,7 @@ export class AWS {
   slowRetryStrategy: StandardRetryStrategy;
   codeBuildRetryStrategy: StandardRetryStrategy;
 
-  constructor(config: AWSConfig) {
+  constructor(awsConfig: AWSConfig) {
     // declare a specific slow retry strategy, to reuse in slow apis
     this.slowRetryStrategy = new StandardRetryStrategy(async () => SLOW_STRATEGY_RETRIES, {
       retryDecider: error => {
@@ -90,7 +90,7 @@ export class AWS {
         if (!error) {
           return false;
         }
-        if (IASQL_ENV === 'test' && error.message.includes('AWS SDK error wrapper')) {
+        if (!!config.overrideAwsRetryDecider && error.message.includes('AWS SDK error wrapper')) {
           // jest has messed the error object
           return true;
         }

--- a/src/services/aws_macros.ts
+++ b/src/services/aws_macros.ts
@@ -88,7 +88,7 @@ export class AWS {
         if (!error) {
           return false;
         }
-        if (error.message.includes('AWS SDK error wrapper'))
+        if (!error.message.includes('AWS SDK error wrapper'))
           // default behavior when running outside Jest
           return defaultRetryDecider(error);
         else return true; // jest has messed the error object

--- a/test/functional/aws-error-jest.ts
+++ b/test/functional/aws-error-jest.ts
@@ -2,7 +2,6 @@ import { AWS } from '../../src/services/aws_macros';
 
 jest.setTimeout(3000000);
 
-
 describe('Jest-AWS Error Issue', () => {
   it('triggers AWS error to inspect', async () => {
     // use a debugger to inspect internal sdk error object
@@ -14,9 +13,7 @@ describe('Jest-AWS Error Issue', () => {
       region: 'us-east-1',
     });
     const results = await Promise.all(
-      [...Array(100).keys()].map(async () =>
-        await client.s3Client.listBuckets({}),
-      ),
+      [...Array(100).keys()].map(async () => await client.s3Client.listBuckets({})),
     );
   });
 });

--- a/test/functional/aws-error-jest.ts
+++ b/test/functional/aws-error-jest.ts
@@ -1,0 +1,22 @@
+import { AWS } from '../../src/services/aws_macros';
+
+jest.setTimeout(3000000);
+
+
+describe('Jest-AWS Error Issue', () => {
+  it('triggers AWS error to inspect', async () => {
+    // use a debugger to inspect internal sdk error object
+    const client = new AWS({
+      credentials: {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      },
+      region: 'us-east-1',
+    });
+    const results = await Promise.all(
+      [...Array(100).keys()].map(async () =>
+        await client.s3Client.listBuckets({}),
+      ),
+    );
+  });
+});

--- a/test/functional/aws-error-without-jest.ts
+++ b/test/functional/aws-error-without-jest.ts
@@ -1,0 +1,20 @@
+import { AWS } from '../../src/services/aws_macros';
+
+const client = new AWS({
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+  },
+  region: 'us-east-1',
+});
+
+async function triggerAwsError() {
+  // use a debugger to inspect internal sdk error object
+  return await Promise.all(
+    [...Array(100).keys()].map(async () =>
+      await client.s3Client.listBuckets({}),
+    ),
+  );
+}
+
+triggerAwsError().then();

--- a/test/functional/aws-error-without-jest.ts
+++ b/test/functional/aws-error-without-jest.ts
@@ -10,11 +10,7 @@ const client = new AWS({
 
 async function triggerAwsError() {
   // use a debugger to inspect internal sdk error object
-  return await Promise.all(
-    [...Array(100).keys()].map(async () =>
-      await client.s3Client.listBuckets({}),
-    ),
-  );
+  return await Promise.all([...Array(100).keys()].map(async () => await client.s3Client.listBuckets({})));
 }
 
 triggerAwsError().then();


### PR DESCRIPTION
Jest [has issues](https://github.com/facebook/jest/issues/11808) with `instance of` calls. And the AWS SDK is using `instanceof Error` and `instanceof Object` to check the error object in order to decide whether it should do a retry on API error or not.
As a result we see errors in CI tests [not being retried](https://github.com/iasql/iasql-engine/actions/runs/3675331590/jobs/6215623047#step:9:423) and causes jobs to fail.

https://backend.cafe/should-you-use-jest-as-a-testing-library

https://github.com/aws/aws-sdk-js-v3/issues/4273