### PR TITLE
Remove the redundant delete because it's an impossible case

### DIFF
--- a/src/modules/aws_ecr/index.ts
+++ b/src/modules/aws_ecr/index.ts
@@ -626,7 +626,7 @@ class RepositoryPolicyMapper extends MapperBase<RepositoryPolicy> {
       const opts = repositoryName
         ? {
             where: {
-              repositoryName,
+              repository: { repositoryName },
               region,
             },
           }

--- a/src/modules/aws_ecr/index.ts
+++ b/src/modules/aws_ecr/index.ts
@@ -626,7 +626,7 @@ class RepositoryPolicyMapper extends MapperBase<RepositoryPolicy> {
       const opts = repositoryId
         ? {
             where: {
-              repositoryId,
+              repository: { id: repositoryId },
               region,
             },
           }

--- a/src/modules/aws_ecr/index.ts
+++ b/src/modules/aws_ecr/index.ts
@@ -543,10 +543,6 @@ class RepositoryMapper extends MapperBase<Repository> {
       for (const e of es) {
         const client = (await ctx.getAwsClient(e.region)) as AWS;
         await this.deleteECRRepository(client.ecrClient, e.repositoryName!);
-        // Also need to delete the repository policy associated with this repository,
-        // if any
-        const policy = await this.module.repositoryPolicy.db.read(ctx, this.entityId(e));
-        await this.module.repositoryPolicy.db.delete(policy, ctx);
       }
     },
   });

--- a/src/modules/aws_ecr/index.ts
+++ b/src/modules/aws_ecr/index.ts
@@ -617,6 +617,24 @@ class RepositoryPolicyMapper extends MapperBase<RepositoryPolicy> {
     }),
   );
 
+  db = new Crud2<RepositoryPolicy>({
+    create: (es: RepositoryPolicy[], ctx: Context) => ctx.orm.save(RepositoryPolicy, es),
+    update: (es: RepositoryPolicy[], ctx: Context) => ctx.orm.save(RepositoryPolicy, es),
+    delete: (es: RepositoryPolicy[], ctx: Context) => ctx.orm.remove(RepositoryPolicy, es),
+    read: async (ctx: Context, id?: string) => {
+      const [repositoryId, region] = id?.split('|') ?? [undefined, undefined];
+      const opts = repositoryId
+        ? {
+            where: {
+              repositoryId,
+              region,
+            },
+          }
+        : {};
+      return await ctx.orm.find(RepositoryPolicy, opts);
+    },
+  });
+
   cloud: Crud2<RepositoryPolicy> = new Crud2({
     create: async (es: RepositoryPolicy[], ctx: Context) => {
       const out = [];

--- a/src/modules/aws_ecr/index.ts
+++ b/src/modules/aws_ecr/index.ts
@@ -622,11 +622,11 @@ class RepositoryPolicyMapper extends MapperBase<RepositoryPolicy> {
     update: (es: RepositoryPolicy[], ctx: Context) => ctx.orm.save(RepositoryPolicy, es),
     delete: (es: RepositoryPolicy[], ctx: Context) => ctx.orm.remove(RepositoryPolicy, es),
     read: async (ctx: Context, id?: string) => {
-      const [repositoryId, region] = id?.split('|') ?? [undefined, undefined];
-      const opts = repositoryId
+      const [repositoryName, region] = id?.split('|') ?? [undefined, undefined];
+      const opts = repositoryName
         ? {
             where: {
-              repository: { id: repositoryId },
+              repositoryName,
               region,
             },
           }

--- a/src/modules/aws_ecr/index.ts
+++ b/src/modules/aws_ecr/index.ts
@@ -617,24 +617,6 @@ class RepositoryPolicyMapper extends MapperBase<RepositoryPolicy> {
     }),
   );
 
-  db = new Crud2<RepositoryPolicy>({
-    create: (es: RepositoryPolicy[], ctx: Context) => ctx.orm.save(RepositoryPolicy, es),
-    update: (es: RepositoryPolicy[], ctx: Context) => ctx.orm.save(RepositoryPolicy, es),
-    delete: (es: RepositoryPolicy[], ctx: Context) => ctx.orm.remove(RepositoryPolicy, es),
-    read: async (ctx: Context, id?: string) => {
-      const [repositoryName, region] = id?.split('|') ?? [undefined, undefined];
-      const opts = repositoryName
-        ? {
-            where: {
-              repositoryName,
-              region,
-            },
-          }
-        : {};
-      return await ctx.orm.find(RepositoryPolicy, opts);
-    },
-  });
-
   cloud: Crud2<RepositoryPolicy> = new Crud2({
     create: async (es: RepositoryPolicy[], ctx: Context) => {
       const out = [];


### PR DESCRIPTION
```ts
export class RepositoryPolicy {
...
  @OneToOne(() => Repository, { nullable: false, eager: true })
  @JoinColumn([
    {
      name: 'repository_id',
      referencedColumnName: 'id',
    },
    // we defined this one to make sure we are using the right region
    {
      name: 'region',
      referencedColumnName: 'region',
    },
  ])
  repository: Repository;
...
}
```
It has `nullable: false`. So all `repositoryPolicy` objects related to a repository should be first deleted in order for it to be deleted from the database. Therefore that additional read/delete is redundant and can be deleted.